### PR TITLE
[Halpy-304] Establish Source of Truth

### DIFF
--- a/CLI/BackupFactUpdater/__main__.py
+++ b/CLI/BackupFactUpdater/__main__.py
@@ -59,7 +59,8 @@ def run_facts():
         with engine.connect() as conn:
             result = conn.execute(
                 text(
-                    f"SELECT factName, factLang, factText FROM {table}",
+                    "SELECT factName, factLang, factText FROM :table",
+                    table=table,
                 )
             )
             print("60% Got data, parsing...")

--- a/CLI/BackupFactUpdater/__main__.py
+++ b/CLI/BackupFactUpdater/__main__.py
@@ -58,10 +58,7 @@ def run_facts():
         print("40% Connection started...")
         with engine.connect() as conn:
             result = conn.execute(
-                text(
-                    "SELECT factName, factLang, factText FROM :table",
-                    table=table,
-                )
+                text("SELECT factName, factLang, factText FROM {}".format(table)),
             )
             print("60% Got data, parsing...")
             for (name, lang, facttext) in result:

--- a/CLI/BackupFactUpdater/__main__.py
+++ b/CLI/BackupFactUpdater/__main__.py
@@ -58,7 +58,9 @@ def run_facts():
         print("40% Connection started...")
         with engine.connect() as conn:
             result = conn.execute(
-                text("SELECT factName, factLang, factText FROM {}".format(table)),
+                text(
+                    f"SELECT factName, factLang, factText FROM {table}",
+                )
             )
             print("60% Got data, parsing...")
             for (name, lang, facttext) in result:

--- a/halpybot/commands/bot_help.py
+++ b/halpybot/commands/bot_help.py
@@ -8,15 +8,11 @@ Licensed under the GNU General Public License
 See license.md
 """
 
-import json
 from typing import List
 import git
 from halpybot import __version__
 from ..packages.command import Commands, get_help_text
 from ..packages.models import Context
-
-with open("data/help/commands.json", "r", encoding="UTF-8") as jsonfile:
-    json_dict = json.load(jsonfile)
 
 
 @Commands.command("help")
@@ -30,18 +26,18 @@ async def hbot_help(ctx: Context, args: List[str]):
     if not args:
         # Return low detail list of commands
         help_string = ""
-        for catagory, command_dict in json_dict.items():
+        for catagory, command_dict in ctx.bot.commandsfile.items():
             help_string += catagory + "\n"
             help_string += "        " + ", ".join(command_dict) + "\n"
         # Remove final line break
         help_string = help_string[:-1]
         return await ctx.redirect(help_string)
     # A specific command has been queried
-    help_text = get_help_text(" ".join(args))
+    help_text = get_help_text(ctx.bot.commandsfile, " ".join(args))
     if help_text is not None:
         return await ctx.reply(help_text)
     for arg in args:
-        help_text = get_help_text(arg)
+        help_text = get_help_text(ctx.bot.commandsfile, arg)
 
         if help_text is None:
             await ctx.reply(

--- a/halpybot/commands/bot_help.py
+++ b/halpybot/commands/bot_help.py
@@ -47,7 +47,8 @@ async def hbot_help(ctx: Context, args: List[str]):
                     help_string += "        " + ", ".join(command_dict) + "\n"
                 # Remove final line break
                 help_string = help_string[:-1]
-                return await ctx.redirect(help_string)
+                if len(help_string) != 0:
+                    return await ctx.redirect(help_string)
 
             await ctx.reply(
                 f"The command {arg} could not be found in the list. Try running help without an argument to get"

--- a/halpybot/commands/bot_help.py
+++ b/halpybot/commands/bot_help.py
@@ -26,8 +26,8 @@ async def hbot_help(ctx: Context, args: List[str]):
     if not args:
         # Return low detail list of commands
         help_string = ""
-        for catagory, command_dict in ctx.bot.commandsfile.items():
-            help_string += catagory + "\n"
+        for category, command_dict in ctx.bot.commandsfile.items():
+            help_string += category + "\n"
             help_string += "        " + ", ".join(command_dict) + "\n"
         # Remove final line break
         help_string = help_string[:-1]
@@ -40,6 +40,15 @@ async def hbot_help(ctx: Context, args: List[str]):
         help_text = get_help_text(ctx.bot.commandsfile, arg)
 
         if help_text is None:
+            help_string = ""
+            for category, command_dict in ctx.bot.commandsfile.items():
+                if arg == category:
+                    help_string += category + "\n"
+                    help_string += "        " + ", ".join(command_dict) + "\n"
+                # Remove final line break
+                help_string = help_string[:-1]
+                return await ctx.redirect(help_string)
+
             await ctx.reply(
                 f"The command {arg} could not be found in the list. Try running help without an argument to get"
                 f" the list of commands"

--- a/halpybot/commands/drill.py
+++ b/halpybot/commands/drill.py
@@ -40,7 +40,7 @@ async def cmd_drillcase(ctx: Context, args: List[str]):
     args = [x.strip(" ") for x in args]
     args = [ele for ele in args if ele.strip()]
     if len(args) < 4:
-        return await ctx.reply(get_help_text("drillcase"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "drillcase"))
     system = await sys_cleaner(args[2])
     await ctx.reply(
         f"xxxx DRILL -- DRILL -- DRILL xxxx\n"
@@ -67,7 +67,7 @@ async def cmd_drillkfcase(ctx: Context, args: List[str]):
     args = [x.strip(" ") for x in args]
     args = [ele for ele in args if ele.strip()]
     if len(args) < 6:
-        return await ctx.reply(get_help_text("drillkfcase"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "drillkfcase"))
     system = await sys_cleaner(args[2])
     await ctx.reply(
         f"xxxx DRILL -- DRILL -- DRILL xxxx\n"
@@ -96,7 +96,7 @@ async def cmd_drillcbcase(ctx: Context, args: List[str]):
     args = [x.strip(" ") for x in args]
     args = [ele for ele in args if ele.strip()]
     if len(args) < 6:
-        return await ctx.reply(get_help_text("drillcbcase"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "drillcbcase"))
     system = await sys_cleaner(args[2])
     await ctx.reply(
         f"xxxx DRILL -- DRILL -- DRILL xxxx\n"

--- a/halpybot/commands/edsm.py
+++ b/halpybot/commands/edsm.py
@@ -38,13 +38,13 @@ async def cmd_systemlookup(ctx: Context, args: List[str]):
     """
 
     if len(args) == 0:
-        return await ctx.reply(get_help_text("lookup"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "lookup"))
     cache_override = False
     if args[0] == "--new":
         cache_override = True
         del args[0]
         if not args:
-            return await ctx.reply(get_help_text("lookup"))
+            return await ctx.reply(get_help_text(ctx.bot.commandsfile, "lookup"))
 
     # For whoever find's this note, you're not crazy. arg[0:] == arg. You get a gold star
     # Gitblame means no gold star for Rik
@@ -79,13 +79,13 @@ async def cmd_cmdrlocate(ctx: Context, args: List[str]):
     """
 
     if len(args) == 0:
-        return await ctx.reply(get_help_text("locatecmdr"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "locatecmdr"))
     cache_override = False
     if args[0] == "--new":
         cache_override = True
         del args[0]
         if not args:
-            return await ctx.reply(get_help_text("locatecmdr"))
+            return await ctx.reply(get_help_text(ctx.bot.commandsfile, "locatecmdr"))
 
     # No. Only 1 gold star per stupid thing
     cmdr = " ".join(args[0:]).strip()
@@ -119,13 +119,13 @@ async def cmd_distlookup(ctx: Context, args: List[str]):
     Aliases: dist
     """
     if len(args) <= 1:  # Minimum Number of Args is 2.
-        return await ctx.reply(get_help_text("dist"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "dist"))
     cache_override = False
     if args[0] == "--new":
         cache_override = True
         del args[0]
         if not args:
-            return await ctx.reply(get_help_text("dist"))
+            return await ctx.reply(get_help_text(ctx.bot.commandsfile, "dist"))
 
     try:
         # Parse systems/CMDRs from string
@@ -172,13 +172,13 @@ async def cmd_landmarklookup(ctx: Context, args: List[str]):
     cache_override = False
 
     if len(args) == 0:
-        return await ctx.reply(get_help_text("landmark"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "landmark"))
     if args[0] == "--new":
         cache_override = True
         del args[0]
         ctx.message = " ".join(args)
         if not ctx.message:
-            return await ctx.reply(get_help_text("landmark"))
+            return await ctx.reply(get_help_text(ctx.bot.commandsfile, "landmark"))
 
     system = ctx.message.strip()
     system = await sys_cleaner(system)
@@ -223,13 +223,13 @@ async def cmd_dssalookup(ctx: Context, args: List[str]):
     cache_override = False
 
     if len(args) == 0:
-        return await ctx.reply(get_help_text("dssa"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "dssa"))
     if args[0] == "--new":
         cache_override = True
         del args[0]
         ctx.message = " ".join(args)
         if not ctx.message:
-            return await ctx.reply(get_help_text("dssa"))
+            return await ctx.reply(get_help_text(ctx.bot.commandsfile, "dssa"))
 
     system = ctx.message.strip()
     system = await sys_cleaner(system)
@@ -266,7 +266,7 @@ async def cmd_coordslookup(ctx, args: List[str]):
     """
     system = None
     if len(args) <= 2:  # Minimum Number of Args is 3.
-        return await ctx.reply(get_help_text("coords"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "coords"))
     xcoord = args[0].strip()
     ycoord = args[1].strip()
     zcoord = args[2].strip()
@@ -312,13 +312,13 @@ async def cmd_diversionlookup(ctx: Context, args: List[str]):
     cache_override = False
 
     if len(args) == 0:
-        return await ctx.reply(get_help_text("diversion"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "diversion"))
     if args[0] == "--new":
         cache_override = True
         del args[0]
         ctx.message = " ".join(args)
         if not ctx.message:
-            return await ctx.reply(get_help_text("diversion"))
+            return await ctx.reply(get_help_text(ctx.bot.commandsfile, "diversion"))
     system = ctx.message.strip()
     cleaned_sys = await sys_cleaner(system)
 

--- a/halpybot/commands/fact.py
+++ b/halpybot/commands/fact.py
@@ -54,7 +54,7 @@ async def cmd_getfactdata(ctx: Context, args: List[str]):
     Aliases: n/a
     """
     if not args or len(args) != 1:
-        return await ctx.reply(get_help_text("factinfo"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "factinfo"))
     name, lang = await splitter(args)
     fact: Optional[Fact] = await ctx.bot.facts.get(name, lang)
     if fact is None:
@@ -83,7 +83,7 @@ async def cmd_addfact(ctx: Context, args: List[str]):
     """
 
     if not args or len(args) < 2:
-        return await ctx.reply(get_help_text("addfact"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "addfact"))
     name, lang = await splitter(args)
     if lang not in ctx.bot.langcodes:
         return await ctx.reply(
@@ -125,7 +125,7 @@ async def cmd_deletefact(ctx: Context, args: List[str]):
     Aliases: n/a
     """
     if not args or len(args) != 1:
-        return await ctx.reply(get_help_text("deletefact"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "deletefact"))
     name, lang = await splitter(args)
     if await ctx.bot.facts.get(name, lang) is None:
         return await ctx.reply("That fact does not exist.")
@@ -190,7 +190,7 @@ async def cmd_editfact(ctx: Context, args: List[str]):
     Aliases: updatefact
     """
     if not args or len(args) < 2:
-        return await ctx.reply(get_help_text("editfact"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "editfact"))
 
     name, lang = await splitter(args)
 

--- a/halpybot/commands/fact.py
+++ b/halpybot/commands/fact.py
@@ -21,10 +21,7 @@ from ..packages.facts import (
 )
 from ..packages.checks import Require, Moderator, Admin, Cyberseal
 from ..packages.database import NoDatabaseConnection
-from ..packages.utils import language_codes, strip_non_ascii
-
-
-langcodes = language_codes()
+from ..packages.utils import strip_non_ascii
 
 
 async def splitter(fact_payload):
@@ -65,8 +62,8 @@ async def cmd_getfactdata(ctx: Context, args: List[str]):
     langlist = await ctx.bot.facts.lang_by_fact(name)
     reply = (
         f"Fact: {fact.name}\n"
-        f"Language: {langcodes[lang.casefold()]} ({fact.language})\n"
-        f"All langs: {', '.join(f'{langcodes[lan.casefold()]} ({lan.upper()})' for lan in langlist)}\n"
+        f"Language: {ctx.bot.langcodes[lang.casefold()]} ({fact.language})\n"
+        f"All langs: {', '.join(f'{ctx.bot.langcodes[lan.casefold()]} ({lan.upper()})' for lan in langlist)}\n"
         f"ID: {fact.ID}\n"
         f"Author: {fact.author}\n"
         f"Text: {fact.raw_text}"
@@ -88,7 +85,7 @@ async def cmd_addfact(ctx: Context, args: List[str]):
     if not args or len(args) < 2:
         return await ctx.reply(get_help_text("addfact"))
     name, lang = await splitter(args)
-    if lang not in langcodes:
+    if lang not in ctx.bot.langcodes:
         return await ctx.reply(
             "Cannot comply: Language code must be ISO-639-1 compliant."
         )
@@ -165,7 +162,7 @@ async def cmd_listfacts(ctx: Context, args: List[str]):
         lang = args[0].casefold()
 
     # Input validation
-    if lang not in langcodes:
+    if lang not in ctx.bot.langcodes:
         return await ctx.redirect(
             "Cannot comply: Please specify a valid language code."
         )
@@ -173,9 +170,11 @@ async def cmd_listfacts(ctx: Context, args: List[str]):
     factlist = ctx.bot.facts.list(lang)
 
     if len(factlist) == 0:
-        return await ctx.redirect(f"No {langcodes[lang.casefold()]} facts found.")
+        return await ctx.redirect(
+            f"No {ctx.bot.langcodes[lang.casefold()]} facts found."
+        )
     return await ctx.redirect(
-        f"All {langcodes[lang.casefold()]} facts:\n"
+        f"All {ctx.bot.langcodes[lang.casefold()]} facts:\n"
         f"{', '.join(fact for fact in factlist)}"
     )
 

--- a/halpybot/commands/forcejoin.py
+++ b/halpybot/commands/forcejoin.py
@@ -28,7 +28,7 @@ async def cmd_sajoin(ctx: Context, args: List[str]):
     Aliases: n/a
     """
     if len(args) <= 1:
-        return await ctx.reply(get_help_text("forcejoin"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "forcejoin"))
 
     # Convert channel name to lower case to avoid issues with the already-in-channel check
     args[1] = args[1].casefold()
@@ -75,7 +75,7 @@ async def cmd_rrjoin(ctx: Context, args: List[str]):
     Aliases: n/a
     """
     if len(args) == 0:
-        return await ctx.reply(get_help_text("rrjoin"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "rrjoin"))
 
     botuser = await User.get_info(ctx.bot, ctx.bot.nickname)
 

--- a/halpybot/commands/manual_case.py
+++ b/halpybot/commands/manual_case.py
@@ -18,6 +18,25 @@ from ..packages.models import Context, User
 from ..packages.announcer import send_webhook, WebhookSendError
 
 
+async def send_message(message_content, sender, embeds):
+    """
+    Send a message to Discord
+
+    """
+    cn_message = {
+        "content": message_content,
+        "username": sender,
+        "avatar_url": "https://hullseals.space/images/emblem_mid.png",
+        "tts": False,
+        "embeds": embeds,
+    }
+    await send_webhook(
+        hook_id=config.discord_notifications.webhook_id,
+        hook_token=config.discord_notifications.webhook_token.get_secret_value(),
+        body=cn_message,
+    )
+
+
 @Commands.command("manualcase", "mancase", "manualfish", "manfish")
 @Require.permission(Drilled)
 @Require.channel()
@@ -51,12 +70,10 @@ async def cmd_manual_case(ctx: Context, args: List[str]):
     )
 
     # Send to Discord
-    cn_message = {
-        "content": f"New Incoming Case - {config.discord_notifications.case_notify}",
-        "username": "HalpyBOT",
-        "avatar_url": "https://hullseals.space/images/emblem_mid.png",
-        "tts": False,
-        "embeds": [
+    message_content = f"New Incoming Case - {config.discord_notifications.case_notify}"
+    sender = "HalpyBOT"
+    embeds = (
+        [
             {
                 "title": "New Manual Case!",
                 "type": "rich",
@@ -76,14 +93,9 @@ async def cmd_manual_case(ctx: Context, args: List[str]):
                 ],
             }
         ],
-    }
-
+    )
     try:
-        await send_webhook(
-            hook_id=config.discord_notifications.webhook_id,
-            hook_token=config.discord_notifications.webhook_token.get_secret_value(),
-            body=cn_message,
-        )
+        await send_message(message_content, sender, embeds)
     except WebhookSendError:
         logger.exception("Webhook could not be sent.")
         await ctx.reply(
@@ -104,35 +116,25 @@ async def cmd_tsping(ctx: Context, args: List[str]):
     if len(args) == 0:
         return await ctx.reply(get_help_text(ctx.bot.commandsfile, "tsping"))
     info = ctx.message
-
-    cn_message = {
-        "content": f"Attention, {config.discord_notifications.trained_role}! Seals are needed for this case.",
-        "username": f"{ctx.sender}",
-        "avatar_url": "https://hullseals.space/images/emblem_mid.png",
-        "tts": False,
-        "embeds": [
-            {
-                "title": "Dispatcher Needs Seals",
-                "type": "rich",
-                "timestamp": f"{datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%S.000Z')}",
-                "color": 16093727,
-                "footer": {
-                    "text": f"Sent by {ctx.sender} from {ctx.channel}",
-                    "icon_url": "https://hullseals.space/images/emblem_mid.png",
-                },
-                "fields": [
-                    {"name": "Additional information", "value": info, "inline": False}
-                ],
-            }
-        ],
-    }
-
+    message_content = f"Attention, {config.discord_notifications.trained_role}! Seals are needed for this case."
+    sender = ctx.sender
+    embeds = [
+        {
+            "title": "Dispatcher Needs Seals",
+            "type": "rich",
+            "timestamp": f"{datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%S.000Z')}",
+            "color": 16093727,
+            "footer": {
+                "text": f"Sent by {ctx.sender} from {ctx.channel}",
+                "icon_url": "https://hullseals.space/images/emblem_mid.png",
+            },
+            "fields": [
+                {"name": "Additional information", "value": info, "inline": False}
+            ],
+        }
+    ]
     try:
-        await send_webhook(
-            hook_id=config.discord_notifications.webhook_id,
-            hook_token=config.discord_notifications.webhook_token.get_secret_value(),
-            body=cn_message,
-        )
+        await send_message(message_content, sender, embeds)
     except WebhookSendError:
         logger.exception("Webhook could not be sent.")
         await ctx.reply(

--- a/halpybot/commands/manual_case.py
+++ b/halpybot/commands/manual_case.py
@@ -21,7 +21,6 @@ from ..packages.announcer import send_webhook, WebhookSendError
 async def send_message(message_content, sender, embeds):
     """
     Send a message to Discord
-
     """
     cn_message = {
         "content": message_content,

--- a/halpybot/commands/manual_case.py
+++ b/halpybot/commands/manual_case.py
@@ -29,7 +29,7 @@ async def cmd_manual_case(ctx: Context, args: List[str]):
     Aliases: mancase, manualfish, manfish
     """
     if len(args) <= 1:
-        return await ctx.reply(get_help_text("mancase"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "mancase"))
 
     # Shockingly, I couldn't find an easier way to do this. If you find one, let me know.
     try:
@@ -37,7 +37,7 @@ async def cmd_manual_case(ctx: Context, args: List[str]):
     except AttributeError:
         return await ctx.reply(f"User {args[0]} doesn't appear to exist...")
     except KeyError:
-        return await ctx.reply(get_help_text("mancase"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "mancase"))
 
     info = ctx.message
     logger.info(
@@ -102,7 +102,7 @@ async def cmd_tsping(ctx: Context, args: List[str]):
     Aliases: wssping
     """
     if len(args) == 0:
-        return await ctx.reply(get_help_text("tsping"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "tsping"))
     info = ctx.message
 
     cn_message = {

--- a/halpybot/commands/misc.py
+++ b/halpybot/commands/misc.py
@@ -27,7 +27,7 @@ async def cmd_shorten(ctx: Context, args: List[str]):
     Aliases: n/a
     """
     if not args:
-        return await ctx.reply(get_help_text("shorten"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "shorten"))
     logger.info(f"{ctx.sender} requested shortening of {args[0]}")
     surl = await shorten(args[0])
     return await ctx.reply(f"{ctx.sender}: Here's your short URL: {surl}")
@@ -42,7 +42,7 @@ async def cmd_roll(ctx: Context, args: List[str]):
     Aliases: n/a
     """
     if not args:
-        return await ctx.reply(get_help_text("roll"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "roll"))
     dicesearch = re.search(r"^\d+d\d+$", args[0])
     if dicesearch is not None:
         dice = args[0].split("d")
@@ -54,7 +54,7 @@ async def cmd_roll(ctx: Context, args: List[str]):
             rolls.append(dice_roll)
         total = sum(rolls)
         return await ctx.reply(f"{ctx.sender}: {total} {str(rolls)}")
-    return await ctx.reply(get_help_text("roll"))
+    return await ctx.reply(get_help_text(ctx.bot.commandsfile, "roll"))
 
 
 @Commands.command("fireball")

--- a/halpybot/commands/notify.py
+++ b/halpybot/commands/notify.py
@@ -93,7 +93,9 @@ async def cmd_listnotify(ctx: Context, args: List[str]):
     Aliases: notifyinfo endpoints
     """
     if not args:
-        return await ctx.reply(get_help_text("notifyinfo details"))
+        return await ctx.reply(
+            get_help_text(ctx.bot.commandsfile, "notifyinfo details")
+        )
 
     group = args[0].casefold().strip()
 
@@ -131,7 +133,7 @@ async def cmd_subscribe(ctx: Context, args: List[str]):
     """
 
     if len(args) <= 1:
-        return await ctx.reply(get_help_text("addsub"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "addsub"))
 
     group = args[0].casefold().strip()
 
@@ -170,7 +172,7 @@ async def cmd_notifystaff(ctx: Context, args: List[str]):
     Aliases: !callstaff, !opsig
     """
     if len(args) == 0:
-        return await ctx.reply(get_help_text("opsignal"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "opsignal"))
 
     subject, topic, message = await format_notification(
         "OpSignal", "staff", ctx.sender, args
@@ -201,7 +203,7 @@ async def cmd_notifycybers(ctx: Context, args: List[str]):
     """
 
     if len(args) == 0:
-        return await ctx.reply(get_help_text("cybersignal"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "cybersignal"))
 
     subject, topic, message = await format_notification(
         "CyberSignal", "cybers", ctx.sender, args

--- a/halpybot/commands/ping.py
+++ b/halpybot/commands/ping.py
@@ -15,7 +15,7 @@ import aiohttp
 from ..packages.command import Commands
 from ..packages.checks import Require, Cyberseal
 from ..packages.database import NoDatabaseConnection
-from ..packages.database.connection import latency
+from ..packages.database.connection import test_database_connection
 from ..packages.edsm import GalaxySystem, EDSMLookupError
 from ..packages.models import Context
 from ..packages.utils import web_get
@@ -45,7 +45,7 @@ async def cmd_dbping(ctx: Context, args: List[str]):
     """
     start = time.time()
     try:
-        latencycheck = await latency(ctx.bot.engine)
+        latencycheck = await test_database_connection(ctx.bot.engine)
     except NoDatabaseConnection:
         return await ctx.reply("Unable: No connection.")
     if isinstance(latencycheck, float):

--- a/halpybot/commands/puppet.py
+++ b/halpybot/commands/puppet.py
@@ -26,5 +26,5 @@ async def cmd_say(ctx: Context, args: List[str]):
     Aliases: n/a
     """
     if len(args) <= 1:  # Minimum Number of Args is 2.
-        return await ctx.reply(get_help_text("say"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "say"))
     await ctx.bot.message(str(args[0]), " ".join(args[1:]))

--- a/halpybot/commands/settings.py
+++ b/halpybot/commands/settings.py
@@ -30,7 +30,7 @@ async def cmd_nick(ctx: Context, args: List[str]):
     Aliases: settings nick
     """
     if len(args) == 0:
-        return await ctx.reply(get_help_text("settings nick"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "settings nick"))
     logger.info(
         "NICK CHANGE from {name} to {newName} by {sender}",
         name=config.irc.nickname,
@@ -51,7 +51,7 @@ async def cmd_prefix(ctx: Context, args: List[str]):
     Aliases: settings prefix
     """
     if not args:
-        return await ctx.reply(get_help_text("settings prefix"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "settings prefix"))
     logger.info(
         "PREFIX CHANGE from {prefix} to {new} by {sender}",
         prefix=config.irc.command_prefix,
@@ -77,7 +77,7 @@ async def cmd_offline(ctx: Context, args: List[str]):
     """
     if len(args) == 0:
         return await ctx.reply(
-            f"{get_help_text('settings offline')}\nCurrent "
+            f"{get_help_text(ctx.bot.commandsfile, 'settings offline')}\nCurrent "
             f"offline setting: {config.offline_mode.enabled}"
         )
     if not args[0].casefold() in ("true", "false"):
@@ -107,7 +107,7 @@ async def cmd_joinchannel(ctx: Context, args: List[str]):
     Aliases: n/a
     """
     if len(args) == 0:
-        return await ctx.reply(get_help_text("joinchannel"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "joinchannel"))
     try:
         await ctx.bot.join(args[0])
         return await ctx.reply(f"Bot joined channel {args[0]}")
@@ -127,7 +127,7 @@ async def cmd_part(ctx: Context, args: List[str]):
     Aliases: n/a
     """
     if len(args) == 0:
-        return await ctx.reply(get_help_text("partchannel"))
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "partchannel"))
     try:
         await ctx.bot.part(message=f"Parted by {ctx.sender}", channel=args[0])
         return await ctx.redirect(f"Bot parted channel {args[0]}")

--- a/halpybot/commands/userinfo.py
+++ b/halpybot/commands/userinfo.py
@@ -29,7 +29,7 @@ async def cmd_whois(ctx: Context, args: List[str]):
     Aliases: n/a
     """
     if len(args) == 0:
-        return await ctx.redirect(get_help_text("whois"))
+        return await ctx.redirect(get_help_text(ctx.bot.commandsfile, "whois"))
     cmdr = args[0]
     if cmdr.casefold() == "halpybot":
         return await ctx.redirect(

--- a/halpybot/packages/__init__.py
+++ b/halpybot/packages/__init__.py
@@ -1,0 +1,9 @@
+"""
+__init__.py - Initilization for the bot packages
+
+Copyright (c) The Hull Seals,
+All rights reserved.
+
+Licensed under the GNU General Public License
+See license.md
+"""

--- a/halpybot/packages/announcer/__init__.py
+++ b/halpybot/packages/announcer/__init__.py
@@ -9,14 +9,13 @@ See license.md
 """
 
 from .announcer import Announcer, Announcement, AnnouncementError
-from .twitter import TwitterCasesAcc, Twitter, TwitterConnectionError
+from .twitter import Twitter, TwitterConnectionError
 from .dc_webhook import send_webhook, DiscordWebhookError, WebhookSendError
 
 __all__ = [
     "Announcer",
     "Announcement",
     "AnnouncementError",
-    "TwitterCasesAcc",
     "Twitter",
     "TwitterConnectionError",
     "send_webhook",

--- a/halpybot/packages/announcer/announcer.py
+++ b/halpybot/packages/announcer/announcer.py
@@ -98,9 +98,7 @@ class Announcer:
                 await client.message(channel, await ann.format(args))
             if "Platform" in args.keys():
                 try:
-                    logger.critical("Trying Twitter")
                     await client.twitter.tweet_case(ann, args)
-                    logger.critical("Ending Twitter")
                 except TwitterConnectionError:
                     logger.exception("Unable to send case details to Twitter.")
                     return

--- a/halpybot/packages/announcer/announcer.py
+++ b/halpybot/packages/announcer/announcer.py
@@ -11,7 +11,7 @@ See license.md
 
 from __future__ import annotations
 import json
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, TYPE_CHECKING
 from loguru import logger
 from ..edsm import (
     checklandmarks,
@@ -22,8 +22,10 @@ from ..edsm import (
     sys_cleaner,
     NoNearbyEDSM,
 )
-from .twitter import TwitterCasesAcc, TwitterConnectionError
-from ..ircclient import HalpyBOT
+from .twitter import TwitterConnectionError
+
+if TYPE_CHECKING:
+    from ..ircclient import HalpyBOT
 
 cardinal_flip = {
     "North": "South",
@@ -96,7 +98,9 @@ class Announcer:
                 await client.message(channel, await ann.format(args))
             if "Platform" in args.keys():
                 try:
-                    await TwitterCasesAcc.tweet_case(ann, args)
+                    logger.critical("Trying Twitter")
+                    await client.twitter.tweet_case(ann, args)
+                    logger.critical("Ending Twitter")
                 except TwitterConnectionError:
                     logger.exception("Unable to send case details to Twitter.")
                     return

--- a/halpybot/packages/announcer/twitter.py
+++ b/halpybot/packages/announcer/twitter.py
@@ -65,7 +65,6 @@ class Twitter(tweepy.Client):
             self.__bool__()
         ):  # Eh, this is stupid and unneccesary I guess. Keep it anyway
             try:
-
                 edsm_info = await announcement.get_edsm_data(args, twitter=True)
                 twitmsg = f"{mainline_tw} {edsm_info} Call your jumps, Seals!"
                 auth = tweepy.Client(
@@ -80,6 +79,3 @@ class Twitter(tweepy.Client):
                 raise TwitterConnectionError(err) from err
         else:
             return
-
-
-TwitterCasesAcc = Twitter(wait_on_rate_limit=True)

--- a/halpybot/packages/command/commandhandler.py
+++ b/halpybot/packages/command/commandhandler.py
@@ -10,17 +10,12 @@ See license.md
 
 from __future__ import annotations
 from typing import List, TYPE_CHECKING
-import json
 from loguru import logger
 from halpybot import config
 from ..models import Context
 
 if TYPE_CHECKING:
     from ..ircclient import HalpyBOT
-
-
-with open("data/help/commands.json", "r", encoding="UTF-8") as jsonfile:
-    json_dict = json.load(jsonfile)
 
 
 class CommandException(Exception):
@@ -295,18 +290,19 @@ class CommandGroup:
         return [str(cmd) for cmd in self._command_list if self._command_list[cmd][1]]
 
 
-def get_help_text(search_command: str):
+def get_help_text(commandsfile, search_command: str):
     """
     Retrieve the help text for usage and arguments of a command.
 
     Args:
+        commandsfile (json object): The commandsfile from Context
         search_command (str): The command being looked up in the dictionary
 
     Returns:
         (str or None): Help instructions for a given command, None if unsuccessful.
     """
     search_command = search_command.casefold()
-    for command_dict in json_dict.values():
+    for command_dict in commandsfile.values():
         for command, details in command_dict.items():
             command = command.casefold()
             if command == search_command or search_command in details["aliases"]:

--- a/halpybot/packages/database/__init__.py
+++ b/halpybot/packages/database/__init__.py
@@ -11,11 +11,9 @@ See license.md
 from .connection import (
     NoDatabaseConnection,
     test_database_connection,
-    latency,
 )
 
 __all__ = [
     "NoDatabaseConnection",
     "test_database_connection",
-    "latency",
 ]

--- a/halpybot/packages/database/connection.py
+++ b/halpybot/packages/database/connection.py
@@ -20,17 +20,6 @@ class NoDatabaseConnection(ConnectionError):
     """
 
 
-async def latency(db_engine: engine.Engine):
-    """Ping the database and get latency
-    Returns:
-        Database connection latency
-    """
-    with db_engine.connect() as conn:
-        conn.execute(text("SELECT 'latency'"))
-    end = time.time()
-    return end
-
-
 async def test_database_connection(db_engine: engine.Engine):
     """
     Test the database connection. Set offline mode if an error occurs.
@@ -45,7 +34,7 @@ async def test_database_connection(db_engine: engine.Engine):
             with db_engine.connect() as conn:
                 conn.execute(text("SELECT '1'"))
                 logger.info(f"Succeeded on attempt {attempt}")
-                return
+                return time.time()
         except exc.OperationalError:
             pass
     config.offline_mode.enabled = True

--- a/halpybot/packages/facts/facthandler.py
+++ b/halpybot/packages/facts/facthandler.py
@@ -227,8 +227,9 @@ class FactHandler:
         with db_engine.connect() as database_connection:
             result = database_connection.execute(
                 text(
-                    f"SELECT factID, factName, factLang, factText, factAuthor "
-                    f"FROM {config.facts.table}"
+                    "SELECT factID, factName, factLang, factText, factAuthor "
+                    "FROM :table",
+                    table=config.facts.table,
                 )
             )
             self._flush_cache()
@@ -368,8 +369,9 @@ class FactHandler:
             )
         with db_engine.connect() as database_connection:
             database_connection.execute(
-                text(f"DELETE FROM {config.facts.table} WHERE factID = :fact_id"),
+                text("DELETE FROM :table WHERE factID = :fact_id"),
                 fact_id=self._fact_cache[name, lang].ID,
+                table=config.facts.table,
             )
             del self._fact_cache[name, lang]
 

--- a/halpybot/packages/facts/facthandler.py
+++ b/halpybot/packages/facts/facthandler.py
@@ -228,8 +228,7 @@ class FactHandler:
             result = database_connection.execute(
                 text(
                     "SELECT factID, factName, factLang, factText, factAuthor "
-                    "FROM :table",
-                    table=config.facts.table,
+                    "FROM {}".format(config.facts.table)
                 )
             )
             self._flush_cache()
@@ -369,9 +368,8 @@ class FactHandler:
             )
         with db_engine.connect() as database_connection:
             database_connection.execute(
-                text("DELETE FROM :table WHERE factID = :fact_id"),
+                text("DELETE FROM {} WHERE factID = :fact_id".format(config.facts.table)),
                 fact_id=self._fact_cache[name, lang].ID,
-                table=config.facts.table,
             )
             del self._fact_cache[name, lang]
 

--- a/halpybot/packages/facts/facthandler.py
+++ b/halpybot/packages/facts/facthandler.py
@@ -15,7 +15,7 @@ import re
 from loguru import logger
 from sqlalchemy import text, engine
 from halpybot import config
-from ..database import NoDatabaseConnection
+from ..database import NoDatabaseConnection, test_database_connection
 from ..command import Commands
 
 
@@ -215,12 +215,14 @@ class FactHandler:
 
         """
         try:
+            await test_database_connection(db_engine)
             await self._from_database(db_engine)
         except NoDatabaseConnection:
-            logger.exception("No database connection. Unable to retreive facts.")
+            logger.exception(
+                "Could not fetch facts from DB, backup file loaded and entering OM"
+            )
             if not preserve_current:
                 await self._from_local()
-            raise
 
     async def _from_database(self, db_engine: engine.Engine):
         """Get facts from database and update the cache"""

--- a/halpybot/packages/facts/facthandler.py
+++ b/halpybot/packages/facts/facthandler.py
@@ -227,8 +227,8 @@ class FactHandler:
         with db_engine.connect() as database_connection:
             result = database_connection.execute(
                 text(
-                    "SELECT factID, factName, factLang, factText, factAuthor "
-                    "FROM {}".format(config.facts.table)
+                    f"SELECT factID, factName, factLang, factText, factAuthor "
+                    f"FROM {config.facts.table}"
                 )
             )
             self._flush_cache()
@@ -368,7 +368,7 @@ class FactHandler:
             )
         with db_engine.connect() as database_connection:
             database_connection.execute(
-                text("DELETE FROM {} WHERE factID = :fact_id".format(config.facts.table)),
+                text(f"DELETE FROM {config.facts.table} WHERE factID = :fact_id"),
                 fact_id=self._fact_cache[name, lang].ID,
             )
             del self._fact_cache[name, lang]

--- a/halpybot/packages/facts/facthandler.py
+++ b/halpybot/packages/facts/facthandler.py
@@ -38,7 +38,9 @@ class InvalidFactException(FactHandlerError):
 
 
 class Fact:
-    def __init__(self, ID: Optional[int], name: str, lang: str, text: str, author: str):
+    def __init__(
+        self, ID: Optional[int], name: str, lang: str, fact_text: str, author: str
+    ):
         """Create a new fact
 
         Args:
@@ -46,7 +48,7 @@ class Fact:
                 use None
             name (str): Name of the fact
             lang (str): Fact language ISO-639-1 code
-            text (str): Fact text
+            fact_text (str): Fact fact_text
             author (str): Fact author
 
         """
@@ -55,8 +57,8 @@ class Fact:
         self._name = name
         self._lang = lang
         self._default_argument = None
-        self._text = self._parse_fact(text)
-        self._raw_text = text
+        self._text = self._parse_fact(fact_text)
+        self._raw_text = fact_text
         self._author = author
 
     @property
@@ -95,31 +97,31 @@ class Fact:
         return self._author
 
     @name.setter
-    def name(self, engine: engine.Engine, newname: str):
+    def name(self, db_engine: engine.Engine, newname: str):
         self._name = newname
-        self._write(engine)
+        self._write(db_engine)
 
     @text.setter
-    def text(self, engine: engine.Engine, newtext: str):
+    def text(self, db_engine: engine.Engine, newtext: str):
         self._text = self._parse_fact(newtext)
         self._raw_text = newtext
-        self._write(engine)
+        self._write(db_engine)
 
-    def _parse_fact(self, text: str):
+    def _parse_fact(self, fact_text: str):
         """Parse a fact
 
         Converts b/i/u to control character and parses default argument.
 
         Args:
-            text (str): Fact text to be parsed
+            fact_text (str): Fact text to be parsed
 
         Returns:
             (str): Parsed fact text
 
         """
         re_defarg = re.compile(r"({{(?P<defarg>.+)}})(?P<fact>.+)")
-        groups = re_defarg.search(text)
-        if re.match(re_defarg, text):
+        groups = re_defarg.search(fact_text)
+        if re.match(re_defarg, fact_text):
             self._default_argument = groups.group("defarg")
         repltable = {
             "<<BOLD>>": "\u0002",
@@ -128,12 +130,12 @@ class Fact:
             " %n% ": "\n",
         }
         if self._default_argument:
-            text = groups.group("fact")
+            fact_text = groups.group("fact")
         for token, new in repltable.items():
-            text = text.replace(token, new)
-        return text
+            fact_text = fact_text.replace(token, new)
+        return fact_text
 
-    def _write(self, engine: engine.Engine):
+    def _write(self, db_engine: engine.Engine):
         """Write changes to a fact to the database
 
         Raises:
@@ -148,7 +150,7 @@ class Fact:
         if self._offline:
             raise FactUpdateError
         try:
-            with engine.connect() as database_connection:
+            with db_engine.connect() as database_connection:
                 database_connection.execute(
                     text(
                         f"UPDATE {config.facts.table}"
@@ -198,29 +200,31 @@ class FactHandler:
             return self._fact_cache[name, lang]
         return None
 
-    async def fetch_facts(self, engine: engine.Engine, preserve_current: bool = False):
+    async def fetch_facts(
+        self, db_engine: engine.Engine, preserve_current: bool = False
+    ):
         """Refresh fact cache.
 
         If a database connection is available, we will get the facts from there.
         Else, we get it from the backup files.
 
         Args:
-            engine (engine.Engine): DBAPI Engine
+            db_engine (engine.Engine): DBAPI Engine
             preserve_current (bool): If True, and database connection is not available,
                 we don't attempt to update the fact cache at all and just leave it as it is.
 
         """
         try:
-            await self._from_database(engine)
+            await self._from_database(db_engine)
         except NoDatabaseConnection:
             logger.exception("No database connection. Unable to retreive facts.")
             if not preserve_current:
                 await self._from_local()
             raise
 
-    async def _from_database(self, engine: engine.Engine):
+    async def _from_database(self, db_engine: engine.Engine):
         """Get facts from database and update the cache"""
-        with engine.connect() as database_connection:
+        with db_engine.connect() as database_connection:
             result = database_connection.execute(
                 text(
                     f"SELECT factID, factName, factLang, factText, factAuthor "
@@ -255,7 +259,12 @@ class FactHandler:
         self._fact_cache.clear()
 
     async def add_fact(
-        self, engine: engine.Engine, name: str, lang: str, fact_text: str, author: str
+        self,
+        db_engine: engine.Engine,
+        name: str,
+        lang: str,
+        fact_text: str,
+        author: str,
     ):
         """Add a new fact
 
@@ -264,7 +273,7 @@ class FactHandler:
         to create it.
 
         Args:
-            engine (engine.Engine): DBAPI Engine
+            db_engine (engine.Engine): DBAPI Engine
             name (str): name of the fact
             lang (str): language code, as specified in ISO-639-1
             fact_text (str): Text of the fact, including formatting
@@ -286,7 +295,7 @@ class FactHandler:
             )
         if (name, lang) in self._fact_cache:
             raise InvalidFactException("This fact already exists.")
-        with engine.connect() as database_connection:
+        with db_engine.connect() as database_connection:
             database_connection.execute(
                 text(
                     f"INSERT INTO {config.facts.table} "
@@ -299,7 +308,7 @@ class FactHandler:
                 author=author,
             )
         # Reset the fact handler
-        await self.fetch_facts(engine, preserve_current=True)
+        await self.fetch_facts(db_engine, preserve_current=True)
 
     async def lang_by_fact(self, name: str):
         """Get a list of languages a fact exists in
@@ -337,14 +346,14 @@ class FactHandler:
                 namelist.append(fact[0])
         return namelist
 
-    async def delete_fact(self, engine: engine.Engine, name: str, lang: str = "en"):
+    async def delete_fact(self, db_engine: engine.Engine, name: str, lang: str = "en"):
         """Delete a fact
 
         Fact is immediately deleted from both local storage and the database;
         use with care.
 
         Args:
-            engine (engine.Engine): DBAPI Engine
+            db_engine (engine.Engine): DBAPI Engine
             name (str): Name of the fact to be deleted
             lang (str): Fact language ISO-639-1 code. English by default
 
@@ -357,7 +366,7 @@ class FactHandler:
                 "Cannot delete English fact if other languages "
                 "are registered for that fact name."
             )
-        with engine.connect() as database_connection:
+        with db_engine.connect() as database_connection:
             database_connection.execute(
                 text(f"DELETE FROM {config.facts.table} WHERE factID = :fact_id"),
                 fact_id=self._fact_cache[name, lang].ID,
@@ -394,7 +403,7 @@ class FactHandler:
             arguments (list): List of arguments
 
         Returns:
-            (str): Formatted fact text
+            (str): Formatted fact fact_text
 
         Raises:
             FactHandlerError: Fact was not found

--- a/halpybot/packages/ircclient/halpybot.py
+++ b/halpybot/packages/ircclient/halpybot.py
@@ -19,6 +19,7 @@ from halpybot.packages import utils
 from halpybot import config
 from .. import notify
 from ._listsupport import ListHandler
+from ..announcer import Twitter
 from ..command import Commands, CommandGroup
 from ..facts import FactHandler
 from ...halpyconfig import SaslExternal, SaslPlain
@@ -42,6 +43,7 @@ class HalpyBOT(pydle.Client, ListHandler):
             pool_recycle=3600,
             connect_args={"connect_timeout": config.database.timeout},
         )
+        self._twitter = Twitter(wait_on_rate_limit=True)
 
     @property
     def commandhandler(self):
@@ -52,6 +54,10 @@ class HalpyBOT(pydle.Client, ListHandler):
     def engine(self):
         """Database Connection Engine"""
         return self._engine
+
+    @property
+    def twitter(self):
+        return self._twitter
 
     @commandhandler.setter
     def commandhandler(self, handler: CommandGroup):

--- a/halpybot/packages/ircclient/halpybot.py
+++ b/halpybot/packages/ircclient/halpybot.py
@@ -35,6 +35,7 @@ class HalpyBOT(pydle.Client, ListHandler):
         super().__init__(*args, **kwargs)
         self.facts = FactHandler()
         self._commandhandler: Optional[CommandGroup] = Commands
+        self._commandhandler.facthandler = self.facts
         self._dbconfig = (
             f"{config.database.connection_string}/{config.database.database}"
         )

--- a/halpybot/packages/ircclient/halpybot.py
+++ b/halpybot/packages/ircclient/halpybot.py
@@ -7,7 +7,7 @@ All rights reserved.
 Licensed under the GNU General Public License
 See license.md
 """
-
+import json
 import os
 import signal
 from typing import Optional
@@ -47,6 +47,8 @@ class HalpyBOT(pydle.Client, ListHandler):
         )
         self._twitter = Twitter(wait_on_rate_limit=True)
         self._langcodes = language_codes()
+        with open("data/help/commands.json", "r", encoding="UTF-8") as jsonfile:
+            self._commandsfile = json.load(jsonfile)
 
     @property
     def commandhandler(self):
@@ -67,6 +69,11 @@ class HalpyBOT(pydle.Client, ListHandler):
     def langcodes(self):
         """Language Codes"""
         return self._langcodes
+
+    @property
+    def commandsfile(self):
+        """Commands Help File"""
+        return self._commandsfile
 
     @commandhandler.setter
     def commandhandler(self, handler: CommandGroup):

--- a/halpybot/packages/ircclient/halpybot.py
+++ b/halpybot/packages/ircclient/halpybot.py
@@ -22,6 +22,7 @@ from ._listsupport import ListHandler
 from ..announcer import Twitter
 from ..command import Commands, CommandGroup
 from ..facts import FactHandler
+from ..utils import language_codes
 from ...halpyconfig import SaslExternal, SaslPlain
 from ..database import NoDatabaseConnection, test_database_connection
 
@@ -44,6 +45,7 @@ class HalpyBOT(pydle.Client, ListHandler):
             connect_args={"connect_timeout": config.database.timeout},
         )
         self._twitter = Twitter(wait_on_rate_limit=True)
+        self._langcodes = language_codes()
 
     @property
     def commandhandler(self):
@@ -57,7 +59,13 @@ class HalpyBOT(pydle.Client, ListHandler):
 
     @property
     def twitter(self):
+        """Twitter Linkup"""
         return self._twitter
+
+    @property
+    def langcodes(self):
+        """Language Codes"""
+        return self._langcodes
 
     @commandhandler.setter
     def commandhandler(self, handler: CommandGroup):

--- a/halpybot/packages/ircclient/halpybot.py
+++ b/halpybot/packages/ircclient/halpybot.py
@@ -24,7 +24,6 @@ from ..command import Commands, CommandGroup
 from ..facts import FactHandler
 from ..utils import language_codes
 from ...halpyconfig import SaslExternal, SaslPlain
-from ..database import NoDatabaseConnection, test_database_connection
 
 
 class HalpyBOT(pydle.Client, ListHandler):
@@ -123,13 +122,7 @@ class HalpyBOT(pydle.Client, ListHandler):
             await self.operserv_login()
         if config.system_monitoring.failure_button:
             config.system_monitoring.failure_button = False
-        try:
-            await test_database_connection(self.engine)
-        except NoDatabaseConnection:
-            logger.error(
-                "Could not fetch facts from DB, backup file loaded and entering OM"
-            )
-        await self.facts.fetch_facts(self.engine, preserve_current=False)
+        await self.facts.fetch_facts(self.engine)
         for channel in config.channels.channel_list:
             await self.join(channel, force=True)
         await utils.task_starter(self)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,12 +18,8 @@ from halpybot import commands
 from .fixtures.mock_halpy import TestBot
 
 
-# FIXME
-# @pytest.fixture()
-# async def bot_fx():
-#     """Create a fixture that represents the bot"""
-#
-#     # noinspection PyProtectedMember
-#     await Facts._from_local()  # Allows us to test the Fact module from the pre-packaged JSON file
-#     test_bot = TestBot(nickname="HalpyTest[BOT]")
-#     return test_bot
+@pytest.fixture()
+async def bot_fx():
+    """Create a fixture that represents the bot"""
+    test_bot = TestBot(nickname="HalpyTest[BOT]")
+    return test_bot

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -56,7 +56,7 @@ async def test_botping_dm(bot_fx):
 
 
 @pytest.mark.asyncio
-async def test_lookup(bot_fx, mock_api_server_fx):
+async def test_lookup(bot_fx):
     """Test the lookup command"""
     await Commands.invoke_from_message(
         bot=bot_fx,
@@ -71,7 +71,7 @@ async def test_lookup(bot_fx, mock_api_server_fx):
 
 
 @pytest.mark.asyncio
-async def test_lookup_2(bot_fx, mock_api_server_fx):
+async def test_lookup_2(bot_fx):
     """Test the lookup command with no arguments"""
     await Commands.invoke_from_message(
         bot=bot_fx,
@@ -89,7 +89,7 @@ async def test_lookup_2(bot_fx, mock_api_server_fx):
 
 
 @pytest.mark.asyncio
-async def test_lookup_3(bot_fx, mock_api_server_fx):
+async def test_lookup_3(bot_fx):
     """Test the lookup command with an invalid system"""
     await Commands.invoke_from_message(
         bot=bot_fx,
@@ -104,7 +104,7 @@ async def test_lookup_3(bot_fx, mock_api_server_fx):
 
 
 @pytest.mark.asyncio
-async def test_lookup_4(bot_fx, mock_api_server_fx):
+async def test_lookup_4(bot_fx):
     """Test the Lookup command"""
     await Commands.invoke_from_message(
         bot=bot_fx,
@@ -341,7 +341,6 @@ async def test_say_no_args(bot_fx):
     }
 
 
-# FIXME: Rework for Internal DB
 @pytest.mark.asyncio
 async def test_whois_hbot(bot_fx):
     """Test the WHOIS command easter egg"""
@@ -537,6 +536,7 @@ async def test_drillcb_unauth(bot_fx):
     }
 
 
+# FIXME
 # @pytest.mark.asyncio
 # async def test_go_valid(bot_fx):
 #     """Test the GO command"""
@@ -550,29 +550,29 @@ async def test_drillcb_unauth(bot_fx):
 #         "message": "some_pup: You're up.",
 #         "target": "#bot-test",
 #     }
+#
+#
+# @pytest.mark.asyncio
+# async def test_go_guest(bot_fx):
+#     """Test the GO command"""
+#     await Commands.invoke_from_message(
+#         bot=bot_fx,
+#         channel="#bot-test",
+#         sender="generic_seal",
+#         message=f"{config.irc.command_prefix}go guest_user",
+#     )
+#     assert bot_fx.sent_messages[0] == {
+#         "message": "generic_seal: guest_user is not identified as a trained seal. Have them check their IRC setup?",
+#         "target": "#bot-test",
+#     }
+#     assert bot_fx.sent_messages[1] == {
+#         "message": "guest_user: You're up.",
+#         "target": "#bot-test",
+#     }
 
 
 @pytest.mark.asyncio
-async def test_go_guest(bot_fx):
-    """Test the GO command"""
-    await Commands.invoke_from_message(
-        bot=bot_fx,
-        channel="#bot-test",
-        sender="generic_seal",
-        message=f"{config.irc.command_prefix}go guest_user",
-    )
-    assert bot_fx.sent_messages[0] == {
-        "message": "generic_seal: guest_user is not identified as a trained seal. Have them check their IRC setup?",
-        "target": "#bot-test",
-    }
-    assert bot_fx.sent_messages[1] == {
-        "message": "guest_user: You're up.",
-        "target": "#bot-test",
-    }
-
-
-@pytest.mark.asyncio
-async def test_locate(bot_fx, mock_api_server_fx):
+async def test_locate(bot_fx):
     """Test the locate command"""
     await Commands.invoke_from_message(
         bot=bot_fx,
@@ -587,7 +587,7 @@ async def test_locate(bot_fx, mock_api_server_fx):
 
 
 @pytest.mark.asyncio
-async def test_locate_malformed_response(bot_fx, mock_api_server_fx):
+async def test_locate_malformed_response(bot_fx):
     """Test the locate command when EDSM gives a malformed or incomplete response"""
     await Commands.invoke_from_message(
         bot=bot_fx,
@@ -602,7 +602,7 @@ async def test_locate_malformed_response(bot_fx, mock_api_server_fx):
 
 
 @pytest.mark.asyncio
-async def test_locate_2(bot_fx, mock_api_server_fx):
+async def test_locate_2(bot_fx):
     """Test the locate command with no arguments"""
     await Commands.invoke_from_message(
         bot=bot_fx,
@@ -620,7 +620,7 @@ async def test_locate_2(bot_fx, mock_api_server_fx):
 
 
 @pytest.mark.asyncio
-async def test_locate_3(bot_fx, mock_api_server_fx):
+async def test_locate_3(bot_fx):
     """Test the locate command with an invalid name"""
     await Commands.invoke_from_message(
         bot=bot_fx,
@@ -635,7 +635,7 @@ async def test_locate_3(bot_fx, mock_api_server_fx):
 
 
 @pytest.mark.asyncio
-async def test_locate_4(bot_fx, mock_api_server_fx):
+async def test_locate_4(bot_fx):
     """Test the locate command cache override"""
     await Commands.invoke_from_message(
         bot=bot_fx,
@@ -650,7 +650,7 @@ async def test_locate_4(bot_fx, mock_api_server_fx):
 
 
 @pytest.mark.asyncio
-async def test_distance(bot_fx, mock_api_server_fx):
+async def test_distance(bot_fx):
     """Test the distance command"""
     await Commands.invoke_from_message(
         bot=bot_fx,
@@ -665,7 +665,7 @@ async def test_distance(bot_fx, mock_api_server_fx):
 
 
 @pytest.mark.asyncio
-async def test_distance_2(bot_fx, mock_api_server_fx):
+async def test_distance_2(bot_fx):
     """Test the distance command with no arguments"""
     await Commands.invoke_from_message(
         bot=bot_fx,
@@ -683,7 +683,7 @@ async def test_distance_2(bot_fx, mock_api_server_fx):
 
 
 @pytest.mark.asyncio
-async def test_distance_3(bot_fx, mock_api_server_fx):
+async def test_distance_3(bot_fx):
     """Test the distance command with an invalid value"""
     await Commands.invoke_from_message(
         bot=bot_fx,
@@ -698,7 +698,7 @@ async def test_distance_3(bot_fx, mock_api_server_fx):
 
 
 @pytest.mark.asyncio
-async def test_distance_4(bot_fx, mock_api_server_fx):
+async def test_distance_4(bot_fx):
     """Test the distance command with cache override"""
     await Commands.invoke_from_message(
         bot=bot_fx,
@@ -713,7 +713,7 @@ async def test_distance_4(bot_fx, mock_api_server_fx):
 
 
 @pytest.mark.asyncio
-async def test_coords(bot_fx, mock_api_server_fx):
+async def test_coords(bot_fx):
     """Test the coords command"""
     await Commands.invoke_from_message(
         bot=bot_fx,
@@ -728,7 +728,7 @@ async def test_coords(bot_fx, mock_api_server_fx):
 
 
 @pytest.mark.asyncio
-async def test_coords_2(bot_fx, mock_api_server_fx):
+async def test_coords_2(bot_fx):
     """Test the coords command with no arguments"""
     await Commands.invoke_from_message(
         bot=bot_fx,
@@ -746,7 +746,7 @@ async def test_coords_2(bot_fx, mock_api_server_fx):
 
 
 @pytest.mark.asyncio
-async def test_distance_3(bot_fx, mock_api_server_fx):
+async def test_coords_3(bot_fx):
     """Test the coords command with an invalid value"""
     await Commands.invoke_from_message(
         bot=bot_fx,
@@ -761,7 +761,7 @@ async def test_distance_3(bot_fx, mock_api_server_fx):
 
 
 @pytest.mark.asyncio
-async def test_coords_4(bot_fx, mock_api_server_fx):
+async def test_coords_4(bot_fx):
     """Test the coords command with an invalid EDSM value"""
     await Commands.invoke_from_message(
         bot=bot_fx,

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -342,67 +342,67 @@ async def test_say_no_args(bot_fx):
 
 
 # FIXME: Rework for Internal DB
-# @pytest.mark.asyncio
-# async def test_whois_hbot(bot_fx):
-#     """Test the WHOIS command easter egg"""
-#     await Commands.invoke_from_message(
-#         bot=bot_fx,
-#         channel="some_admin",
-#         sender="some_admin",
-#         message=f"{config.irc.command_prefix}whois halpybot",
-#     )
-#     assert bot_fx.sent_messages[0] == {
-#         "message": "That's me! CMDR HalpyBOT has a Seal ID of 0, registered 14.8 billion years ago, is a DW2 Veteran and Founder Seal with registered CMDRs of Arf! Arf! Arf!, and has been involved with countless rescues.",
-#         "target": "some_admin",
-#     }
-#
-#
-# @pytest.mark.asyncio
-# async def test_whois_empty(bot_fx):
-#     """Test the WHOIS command without arguments"""
-#     await Commands.invoke_from_message(
-#         bot=bot_fx,
-#         channel="some_admin",
-#         sender="some_admin",
-#         message=f"{config.irc.command_prefix}whois",
-#     )
-#     assert bot_fx.sent_messages[0] == {
-#         "message": f"Use: {config.irc.command_prefix}whois [name]\nAliases: \nCheck the user information for registered name. Must be a registered user, and run in DMs with HalpyBOT.",
-#         "target": "some_admin",
-#     }
+@pytest.mark.asyncio
+async def test_whois_hbot(bot_fx):
+    """Test the WHOIS command easter egg"""
+    await Commands.invoke_from_message(
+        bot=bot_fx,
+        channel="some_admin",
+        sender="some_admin",
+        message=f"{config.irc.command_prefix}whois halpybot",
+    )
+    assert bot_fx.sent_messages[0] == {
+        "message": "That's me! CMDR HalpyBOT has a Seal ID of 0, registered 14.8 billion years ago, is a DW2 Veteran and Founder Seal with registered CMDRs of Arf! Arf! Arf!, and has been involved with countless rescues.",
+        "target": "some_admin",
+    }
+
+
+@pytest.mark.asyncio
+async def test_whois_empty(bot_fx):
+    """Test the WHOIS command without arguments"""
+    await Commands.invoke_from_message(
+        bot=bot_fx,
+        channel="some_admin",
+        sender="some_admin",
+        message=f"{config.irc.command_prefix}whois",
+    )
+    assert bot_fx.sent_messages[0] == {
+        "message": f"Use: {config.irc.command_prefix}whois [name]\nAliases: \nCheck the user information for registered name. Must be a registered user, and run in DMs with HalpyBOT.",
+        "target": "some_admin",
+    }
 
 
 # FIXME: These two tests need to be reworked to avoid poking the live DB.
-# @pytest.mark.asyncio
-# async def test_whois(bot_fx):
-#     """Test the WHOIS command"""
-#     await Commands.invoke_from_message(
-#         bot=bot_fx,
-#         channel="some_admin",
-#         sender="some_admin",
-#         message=f"{config.irc.command_prefix}whois Rixxan",
-#     )
-#     assert (
-#         bot_fx.sent_messages[0]
-#         .get("message")
-#         .startswith("CMDR Rixxan has a Seal ID of 1")
-#     )
-#
-#
-# @pytest.mark.asyncio
-# async def test_whoami(bot_fx):
-#     """Test the WHOAMI command"""
-#     await Commands.invoke_from_message(
-#         bot=bot_fx,
-#         channel="Rixxan",
-#         sender="Rixxan",
-#         message=f"{config.irc.command_prefix}whoami",
-#     )
-#     assert (
-#         bot_fx.sent_messages[0]
-#         .get("message")
-#         .startswith("CMDR Rixxan has a Seal ID of 1")
-#     )
+@pytest.mark.asyncio
+async def test_whois(bot_fx):
+    """Test the WHOIS command"""
+    await Commands.invoke_from_message(
+        bot=bot_fx,
+        channel="some_admin",
+        sender="some_admin",
+        message=f"{config.irc.command_prefix}whois Rixxan",
+    )
+    assert (
+        bot_fx.sent_messages[0]
+        .get("message")
+        .startswith("CMDR Rixxan has a Seal ID of 1")
+    )
+
+
+@pytest.mark.asyncio
+async def test_whoami(bot_fx):
+    """Test the WHOAMI command"""
+    await Commands.invoke_from_message(
+        bot=bot_fx,
+        channel="Rixxan",
+        sender="Rixxan",
+        message=f"{config.irc.command_prefix}whoami",
+    )
+    assert (
+        bot_fx.sent_messages[0]
+        .get("message")
+        .startswith("CMDR Rixxan has a Seal ID of 1")
+    )
 
 
 @pytest.mark.asyncio
@@ -537,19 +537,19 @@ async def test_drillcb_unauth(bot_fx):
     }
 
 
-@pytest.mark.asyncio
-async def test_go_valid(bot_fx):
-    """Test the GO command"""
-    await Commands.invoke_from_message(
-        bot=bot_fx,
-        channel="#bot-test",
-        sender="generic_seal",
-        message=f"{config.irc.command_prefix}go some_pup",
-    )
-    assert bot_fx.sent_messages[0] == {
-        "message": "some_pup: You're up.",
-        "target": "#bot-test",
-    }
+# @pytest.mark.asyncio
+# async def test_go_valid(bot_fx):
+#     """Test the GO command"""
+#     await Commands.invoke_from_message(
+#         bot=bot_fx,
+#         channel="#bot-test",
+#         sender="generic_seal",
+#         message=f"{config.irc.command_prefix}go some_pup",
+#     )
+#     assert bot_fx.sent_messages[0] == {
+#         "message": "some_pup: You're up.",
+#         "target": "#bot-test",
+#     }
 
 
 @pytest.mark.asyncio

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -10,16 +10,15 @@ See license.md
 
 import time
 import pytest
-from halpybot.packages.database import latency
-from halpybot import config
+from halpybot.packages.database import test_database_connection
 
 
 @pytest.mark.asyncio
-async def test_latency(bot_fx):
+async def test_db(bot_fx):
     """Test the Database Latency.
 
     If it's above 15, the connection is unusable."""
     start = time.time()
-    connection = await latency(bot_fx.engine)
+    connection = await test_database_connection(bot_fx.engine)
     final = round(connection - start, 2)
     assert final < 15

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -13,20 +13,13 @@ import pytest
 from halpybot.packages.database import latency
 from halpybot import config
 
-pytestmark = pytest.mark.skipif(
-    config.offline_mode.enabled,
-    reason="Offline Mode Enabled on database-touching tests! "
-    "Please disable it to continue",
-)
 
+@pytest.mark.asyncio
+async def test_latency(bot_fx):
+    """Test the Database Latency.
 
-# FIXME: Rework for Inbuilt Tests
-# @pytest.mark.asyncio
-# async def test_latency():
-#     """Test the Database Latency.
-#
-#     If it's above 15, the connection is unusable."""
-#     start = time.time()
-#     connection = await latency()
-#     final = round(connection - start, 2)
-#     assert final < 15
+    If it's above 15, the connection is unusable."""
+    start = time.time()
+    connection = await latency(bot_fx.engine)
+    final = round(connection - start, 2)
+    assert final < 15

--- a/tests/test_edsm.py
+++ b/tests/test_edsm.py
@@ -38,7 +38,7 @@ config.edsm.uri = "http://127.0.0.1:4000"
 # Test System
 # 1: Existing sys
 @pytest.mark.asyncio
-async def test_sys(mock_api_server_fx):
+async def test_sys():
     """Test that EDSM returns a valid response for a given system"""
     sys = await GalaxySystem.get_info("Sol", cache_override=True)
     assert sys.name == "Sol"

--- a/tests/test_facts.py
+++ b/tests/test_facts.py
@@ -14,40 +14,40 @@ from halpybot.packages.command import Commands
 from halpybot import config
 
 
-@pytest.mark.asyncio
-async def test_pcfr(bot_fx):
-    """Test if the PCFR fact can be sent from the backup file"""
-    await Commands.invoke_from_message(
-        bot=bot_fx,
-        channel="#bot-test",
-        sender="some_pup",
-        message=f"{config.irc.command_prefix}pcfr",
-    )
-    assert bot_fx.sent_messages[0] == {
-        "message": "Please tap ESC to go to the PAUSE menu, click SOCIAL, enter the CMDR name in the box, and click ADD FRIEND on their name.",
-        "target": "#bot-test",
-    }
+# @pytest.mark.asyncio
+# async def test_pcfr(bot_fx):
+#     """Test if the PCFR fact can be sent from the backup file"""
+#     await Commands.invoke_from_message(
+#         bot=bot_fx,
+#         channel="#bot-test",
+#         sender="some_pup",
+#         message=f"{config.irc.command_prefix}pcfr",
+#     )
+#     assert bot_fx.sent_messages[0] == {
+#         "message": "Please tap ESC to go to the PAUSE menu, click SOCIAL, enter the CMDR name in the box, and click ADD FRIEND on their name.",
+#         "target": "#bot-test",
+#     }
 
 
-@pytest.mark.asyncio
-async def test_factinfo(bot_fx):
-    """Test the factinfo command"""
-    await Commands.invoke_from_message(
-        bot=bot_fx,
-        channel="#bot-test",
-        sender="some_cyber",
-        message=f"{config.irc.command_prefix}factinfo pcfr",
-    )
-    assert bot_fx.sent_messages[1] == {
-        "message": "Fact: pcfr\n"
-        "Language: English (EN)\n"
-        "All langs: English (EN), Dutch (NL)\n"
-        "ID: None\n"
-        "Author: OFFLINE\n"
-        "Text: Please tap ESC to go to the PAUSE menu, click SOCIAL, enter "
-        "the CMDR name in the box, and click ADD FRIEND on their name.",
-        "target": "some_cyber",
-    }
+# @pytest.mark.asyncio
+# async def test_factinfo(bot_fx):
+#     """Test the factinfo command"""
+#     await Commands.invoke_from_message(
+#         bot=bot_fx,
+#         channel="#bot-test",
+#         sender="some_cyber",
+#         message=f"{config.irc.command_prefix}factinfo pcfr",
+#     )
+#     assert bot_fx.sent_messages[1] == {
+#         "message": "Fact: pcfr\n"
+#         "Language: English (EN)\n"
+#         "All langs: English (EN), Dutch (NL)\n"
+#         "ID: None\n"
+#         "Author: OFFLINE\n"
+#         "Text: Please tap ESC to go to the PAUSE menu, click SOCIAL, enter "
+#         "the CMDR name in the box, and click ADD FRIEND on their name.",
+#         "target": "some_cyber",
+#     }
 
 
 @pytest.mark.asyncio
@@ -65,50 +65,49 @@ async def test_factinfo_2(bot_fx):
     }
 
 
-@pytest.mark.asyncio
-async def test_allfacts(bot_fx):
-    """Test the allfacts command"""
-    await Commands.invoke_from_message(
-        bot=bot_fx,
-        channel="generic_seal",
-        sender="generic_seal",
-        message=f"{config.irc.command_prefix}allfacts",
-    )
-    assert bot_fx.sent_messages[0].get("message").startswith("All English facts:")
-
-
-@pytest.mark.asyncio
-async def test_allfacts_2(bot_fx):
-    """Test the allfacts command in Dutch"""
-    await Commands.invoke_from_message(
-        bot=bot_fx,
-        channel="generic_seal",
-        sender="generic_seal",
-        message=f"{config.irc.command_prefix}allfacts nl",
-    )
-    assert bot_fx.sent_messages[0] == {
-        "message": "All Dutch facts:\npcfr",
-        "target": "generic_seal",
-    }
-
-
-# FIXME: Rework for Inbuilt Tests
 # @pytest.mark.asyncio
-# async def test_ufi(bot_fx):
-#     """Test the UFI Command"""
-#     if config.offline_mode.enabled:
-#         pytest.skip("Offline Mode Enabled")
-#     prev_value = config.offline_mode.enabled
-#     config.offline_mode.enabled = False
-#
+# async def test_allfacts(bot_fx):
+#     """Test the allfacts command"""
 #     await Commands.invoke_from_message(
 #         bot=bot_fx,
-#         channel="some_cyber",
-#         sender="some_cyber",
-#         message=f"{config.irc.command_prefix}ufi",
+#         channel="generic_seal",
+#         sender="generic_seal",
+#         message=f"{config.irc.command_prefix}allfacts",
+#     )
+#     assert bot_fx.sent_messages[0].get("message").startswith("All English facts:")
+#
+#
+# @pytest.mark.asyncio
+# async def test_allfacts_2(bot_fx):
+#     """Test the allfacts command in Dutch"""
+#     await Commands.invoke_from_message(
+#         bot=bot_fx,
+#         channel="generic_seal",
+#         sender="generic_seal",
+#         message=f"{config.irc.command_prefix}allfacts nl",
 #     )
 #     assert bot_fx.sent_messages[0] == {
-#         "message": "Fact cache updated.",
-#         "target": "some_cyber",
+#         "message": "All Dutch facts:\npcfr",
+#         "target": "generic_seal",
 #     }
-#     config.offline_mode.enabled = prev_value
+
+
+@pytest.mark.asyncio
+async def test_ufi(bot_fx):
+    """Test the UFI Command"""
+    if config.offline_mode.enabled:
+        pytest.skip("Offline Mode Enabled")
+    prev_value = config.offline_mode.enabled
+    config.offline_mode.enabled = False
+
+    await Commands.invoke_from_message(
+        bot=bot_fx,
+        channel="some_cyber",
+        sender="some_cyber",
+        message=f"{config.irc.command_prefix}ufi",
+    )
+    assert bot_fx.sent_messages[0] == {
+        "message": "Fact cache updated.",
+        "target": "some_cyber",
+    }
+    config.offline_mode.enabled = prev_value

--- a/tests/test_seals.py
+++ b/tests/test_seals.py
@@ -17,38 +17,37 @@ from halpybot import config
 config.offline_mode.enabled = False
 
 
-# FIXME: Rework for Inbuilt Tests
-# @pytest.mark.asyncio
-# async def test_egg_whois():
-#     """Test the WHOIS reply for the fun name"""
-#     user = await whois("HalpyBOT")
-#     user = user[: len(user) // 2]
-#     assert (
-#         user
-#         == "CMDR HalpyBOT has a Seal ID of 235, registered on 2019-12-20, is a DW2 Veteran and Founder Seal "
-#     )
-#
-#
-# @pytest.mark.asyncio
-# async def test_good_whois():
-#     """Test the WHOIS reply for a valid user"""
-#     user = await whois("rik079")
-#     user = user[: len(user) // 3]
-#     assert user == "CMDR rik079 has a Seal ID of 400, registered on 2020-01-15, with r"
-#
-#
-# @pytest.mark.asyncio
-# async def test_bad_whois():
-#     """Test the WHOIS reply for a valid user"""
-#     user = await whois("blargnet")
-#     assert user == "No registered user found by that name!"
-#
-#
-# @pytest.mark.asyncio
-# async def test_offline_whois():
-#     """Test that the WHOIS system responds properly in ONLINE mode"""
-#     prev_value = config.offline_mode.enabled
-#     config.offline_mode.enabled = True
-#     user = await whois("ThisCMDRDoesntExist")
-#     assert user == "No registered user found by that name!"
-#     config.offline_mode.enabled = prev_value
+@pytest.mark.asyncio
+async def test_egg_whois(bot_fx):
+    """Test the WHOIS reply for the fun name"""
+    user = await whois(bot_fx.engine, "HalpyBOT")
+    user = user[: len(user) // 2]
+    assert (
+        user
+        == "CMDR HalpyBOT has a Seal ID of 235, registered on 2019-12-20, is a DW2 Veteran and Founder Seal "
+    )
+
+
+@pytest.mark.asyncio
+async def test_good_whois(bot_fx):
+    """Test the WHOIS reply for a valid user"""
+    user = await whois(bot_fx.engine, "rik079")
+    user = user[: len(user) // 3]
+    assert user == "CMDR rik079 has a Seal ID of 400, registered on 2020-01-15, with r"
+
+
+@pytest.mark.asyncio
+async def test_bad_whois(bot_fx):
+    """Test the WHOIS reply for a valid user"""
+    user = await whois(bot_fx.engine, "blargnet")
+    assert user == "No registered user found by that name!"
+
+
+@pytest.mark.asyncio
+async def test_offline_whois(bot_fx):
+    """Test that the WHOIS system responds properly in ONLINE mode"""
+    prev_value = config.offline_mode.enabled
+    config.offline_mode.enabled = True
+    user = await whois(bot_fx.engine, "ThisCMDRDoesntExist")
+    assert user == "No registered user found by that name!"
+    config.offline_mode.enabled = prev_value

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -56,9 +56,9 @@ def test_commands():
     assert os.path.exists("data/help/commands.json")
 
 
-def test_commands_content():
+def test_commands_content(bot_fx):
     """Test the help file is formatted properly"""
-    assert get_help_text("ping") is not None
+    assert get_help_text(bot_fx.commandsfile, "ping") is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Moves Commands Helpfile, Language Codes, and Twitter control to the Context object. 
- Condenses some duplicate code in Manual Cases
- Adds a missing docstring
- Renames a few variables that mirrored external information
- Re-enables some updated or fixed tests
- Adds back the default fact handler loader
- Reformats fact loading logic
- Fixes a spelling mistake
- Adds category as a valid target for Help command
- Removes a redundant function

Closes #304 