### PR TITLE
[Halpy-311] Add Optional Module Fuses

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -48,11 +48,13 @@ forced_join = '{"joinable": ["#bot-test", "#cybers"]}'
 # logging::file_level = "INFO"
 # logging::log_file="logs/halpybot.log"
 
+discord_notifications::enabled = False
 # discord_notifications::webhook_id = {{DISCORD_WEBHOOK}}
 # discord_notifications::webhook_token = {{DISCORD_TOKEN}}
 # discord_notifications::case_notify =  "{{CASE_NOTIFY_ROLL}}"
 # discord_notifications::trained_role = "{{TRAINED_ROLE }}"
 
+notify::enabled = False
 # notify::staff = ...  #AWS ARN Group for Staff
 # notify::cybers = ...  #AWS ARN Group for Techs
 # notify::region = ...  #aws region in cn-dir-#
@@ -73,6 +75,7 @@ system_monitoring::message_channel = "#bot-test"
 system_monitoring::failure_button = no
 
 # user_agent::agent_comment="YOUR USER AGENT HERE"
+yourls::enabled = False
 # yourls::uri = "https://hullse.al"
 # yourls::pwd = {{YOURLS_PWD}}
 

--- a/halpybot/commands/manual_case.py
+++ b/halpybot/commands/manual_case.py
@@ -69,6 +69,8 @@ async def cmd_manual_case(ctx: Context, args: List[str]):
     )
 
     # Send to Discord
+    if not config.discord_notifications.enabled:
+        return await ctx.reply("Discord module not enabled. Notification not sent.")
     message_content = f"New Incoming Case - {config.discord_notifications.case_notify}"
     sender = "HalpyBOT"
     embeds = (
@@ -114,6 +116,8 @@ async def cmd_tsping(ctx: Context, args: List[str]):
     """
     if len(args) == 0:
         return await ctx.reply(get_help_text(ctx.bot.commandsfile, "tsping"))
+    if not config.discord_notifications.enabled:
+        return await ctx.reply("Discord module not enabled. Notification not sent.")
     info = ctx.message
     message_content = f"Attention, {config.discord_notifications.trained_role}! Seals are needed for this case."
     sender = ctx.sender

--- a/halpybot/commands/misc.py
+++ b/halpybot/commands/misc.py
@@ -11,6 +11,7 @@ import re
 import random
 from typing import List
 from loguru import logger
+from halpybot import config
 from ..packages.utils import shorten
 from ..packages.checks import Require, Drilled, Pup
 from ..packages.command import Commands, get_help_text
@@ -28,6 +29,8 @@ async def cmd_shorten(ctx: Context, args: List[str]):
     """
     if not args:
         return await ctx.reply(get_help_text(ctx.bot.commandsfile, "shorten"))
+    if not config.yourls.enabled:
+        return await ctx.reply("Unable to comply. YOURLS module not enabled.")
     logger.info(f"{ctx.sender} requested shortening of {args[0]}")
     surl = await shorten(args[0])
     return await ctx.reply(f"{ctx.sender}: Here's your short URL: {surl}")

--- a/halpybot/halpyconfig.py
+++ b/halpybot/halpyconfig.py
@@ -143,6 +143,7 @@ class Logging(BaseModel):
 class DiscordNotifications(BaseModel):
     """Discord Notification Config"""
 
+    enabled: bool = False
     webhook_id: Optional[str] = None
     webhook_token: Optional[SecretStr] = None
     case_notify: Optional[constr(regex=r"<@&(\d+)>")] = None
@@ -152,6 +153,7 @@ class DiscordNotifications(BaseModel):
 class Notify(BaseModel):
     """AWS SNS Notification Config"""
 
+    enabled: bool = False
     staff: Optional[str] = None
     cybers: Optional[str] = None
     region: Optional[str] = None

--- a/halpybot/halpyconfig.py
+++ b/halpybot/halpyconfig.py
@@ -226,6 +226,7 @@ class UserAgent(BaseModel):
 class Yourls(BaseModel):
     """YOURLS Linkup Config"""
 
+    enabled: bool = False
     uri: AnyHttpUrl
     pwd: SecretStr
 

--- a/halpybot/packages/checks/checks.py
+++ b/halpybot/packages/checks/checks.py
@@ -185,7 +185,7 @@ class Require:
         def decorator(function):
             @functools.wraps(function)
             async def guarded(ctx, args: List[str]):
-                if not config.notify.secret or not config.notify.access:
+                if not config.notify.enabled:
                     return await ctx.reply(
                         "Cannot comply: AWS Config data is required for this module."
                     )

--- a/halpybot/packages/ircclient/halpybot.py
+++ b/halpybot/packages/ircclient/halpybot.py
@@ -237,6 +237,8 @@ async def crash_notif(crashtype, condition):
         topic = config.notify.cybers
         message = f"HalpyBOT has shut down due to {crashtype}. Investigate immediately. Error Text: {condition}"
         try:
+            if not config.notify.enabled:
+                raise notify.NotificationFailure
             await notify.send_notification(topic, message, subject)
             # Only trip the fuse if a notification is passed
             config.system_monitoring.failure_button = True


### PR DESCRIPTION
Adds a few disconnect fuses to Discord, YOURLS, and AWS Notify modules. 

Defaults to False, and allows fewer passwords and credentials to be passed out, especially for testing versions of HalpyBOT.

Closes #311 