### PR TITLE
Pin black version

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -7,4 +7,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: psf/black@stable
+      - uses: psf/black@22.10.0


### PR DESCRIPTION
This PR pins the black version to  22.10.0 (previous release).

this should prevent recurrences of random CI linting failures caused by black's output changing between versions.﻿
