### PR TITLE
[Cleanup] Remove Unused get_time_seconds function

### DIFF
--- a/halpybot/packages/utils/__init__.py
+++ b/halpybot/packages/utils/__init__.py
@@ -9,7 +9,6 @@ See license.md
 """
 
 from .utils import (
-    get_time_seconds,
     strip_non_ascii,
     language_codes,
     web_get,
@@ -19,7 +18,6 @@ from .shorten import shorten
 
 __all__ = [
     "strip_non_ascii",
-    "get_time_seconds",
     "language_codes",
     "shorten",
     "web_get",

--- a/halpybot/packages/utils/utils.py
+++ b/halpybot/packages/utils/utils.py
@@ -50,31 +50,6 @@ def strip_non_ascii(string: str):
     return res[0], bool(res != (string, 0))
 
 
-async def get_time_seconds(time: str):
-    """Get time in seconds from a hh:mm:ss format
-
-    Args:
-        time (str): Time, in a hh:mm:ss format
-
-    Returns:
-        (int): Time in seconds
-
-    Raises:
-        ValueError: String does not match required format
-
-    """
-    pattern = re.compile(r"(?P<hour>\d+):(?P<minutes>\d+):(?P<seconds>\d+)")
-    if not re.match(pattern, time):
-        raise ValueError("get_time_seconds input does not match hh:mm:ss format")
-    res = pattern.search(time)
-    counter = 0
-    conversion_table = {"hour": 3600, "minutes": 60, "seconds": 1}
-    for unit, seconds in conversion_table.items():
-        value = int(res.group(unit))
-        counter += value * seconds
-    return str(counter)
-
-
 async def web_get(uri: str, params=None, timeout=10):
     """
     Use aiohttp's client to send an HTTP GET request.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,22 +10,8 @@ See license.md
 
 import os.path
 import pytest
-from halpybot.packages.utils import get_time_seconds, language_codes, strip_non_ascii
+from halpybot.packages.utils import language_codes, strip_non_ascii
 from halpybot.packages.command import get_help_text
-
-
-@pytest.mark.asyncio
-async def test_seconds():
-    """Test the time system responds properly"""
-    time = await get_time_seconds("12:34:56")
-    assert time == "45296"
-
-
-@pytest.mark.asyncio
-async def test_seconds_bad():
-    """Test the time system responds properly if an error occurs"""
-    with pytest.raises(ValueError):
-        await get_time_seconds("BACON")
 
 
 def test_lang():


### PR DESCRIPTION
This function isn't actually used anywhere and is an artifact of the old configuration system. It should be removed. 