### PR TITLE
Establish the Case Class and SACM Framework

### DIFF
--- a/data/announcer/announcer_example.json
+++ b/data/announcer/announcer_example.json
@@ -1,51 +1,86 @@
 {
-  "hbot": "1.6.2",
+  "hbot": "2.0",
   "AnnouncerType": [
-
-    {"ID": "PPWK",
-    "Name": "Paperwork",
-    "Description": "Used to inform users of completed paperwork",
-    "Channels": ["#seal-bob", "#Repair-Requests"],
-    "EDSM": false,
-    "Content":  ["Paperwork for case {CMDR} completed by {Seal}. ({Number})"]
+    {
+      "ID": "PPWK",
+      "Name": "Paperwork",
+      "Description": "Used to inform users of completed paperwork",
+      "Channels": [
+        "#seal-bob",
+        "#Repair-Requests"
+      ],
+      "EDSM": false,
+      "Content": [
+        "Paperwork for case {CMDR} completed by {Seal}"
+      ],
+      "Type": "Action"
     },
-
-    {"ID": "CODEBLACK",
-    "Name":  "Code Black",
-    "Description": "Inform users of a new code black case",
-    "Channels": ["#seal-bob", "#Repair-Requests", "#Code-Black"],
-    "EDSM": true,
-    "Content": ["xxxx CBCASE -- NEWCASE -- {Platform}CASE xxx\n",
-                "CMDR: {CMDR} -- Platform: {Platform} -- System: {System} -- Hull: {Hull}\n",
-                "Can synth: {CanSynth} -- O2 timer: {Oxygen}\n",
-                "xxxxxxxx"]
+    {
+      "ID": "TEST",
+      "Name": "Webhook Test",
+      "Description": "Used to validate that HalpyBOT's announcer module is intact.",
+      "Channels": [
+        "#Cybers"
+      ],
+      "EDSM": false,
+      "Content": [
+        "{CMDR} has issued a test of HalpyBOT's announcer. Code 200, all clear."
+      ],
+      "Type": "Other"
     },
-
+    {
+      "ID": "CODEBLACK",
+      "Name": "Code Black",
+      "Description": "Inform users of a new code black case",
+      "Channels": [
+        "#seal-bob",
+        "#Repair-Requests",
+        "#Code-Black"
+      ],
+      "EDSM": true,
+      "Content": [
+        "xxxx CBCASE -- NEWCASE -- {Platform}CASE xxx\n",
+        "CMDR: {CMDR} -- Platform: {Platform} -- System: {System} -- Hull: {Hull}\n",
+        "Can synth: {CanSynth} -- O2 timer: {Oxygen}\n",
+        "xxxxxxxx"
+      ],
+      "Type": "Case"
+    },
     {
       "ID": "SEALCASE",
       "Name": "Seal Case",
       "Description": "Create a new seal case",
-      "Channels": ["#seal-bob, #Repair-Requests"],
+      "Channels": [
+        "#seal-bob",
+        "#Repair-Requests"
+      ],
       "EDSM": true,
-      "Content": ["xxxx {Platform}CASE -- NEWCASE xxxx\n",
-                  "CMDR: {CMDR} -- Platform: {Platform}\n",
-                  "System: {System} -- Hull: {Hull}\n",
-                  "xxxxxxxx"]
+      "Content": [
+        "xxxx {Platform}CASE -- NEWCASE xxxx\n",
+        "CMDR: {CMDR} -- Platform: {Platform}\n",
+        "System: {System} -- Hull: {Hull}\n",
+        "xxxxxxxx"
+      ],
+      "Type": "Case"
     },
-
     {
       "ID": "KFCASE",
       "Name": "Kingfisher case",
       "Description": "Create a new kingfisher case",
-      "Channels": ["#seal-bob", "#Repair-Requests"],
+      "Channels": [
+        "#seal-bob",
+        "#Repair-Requests"
+      ],
       "EDSM": true,
-      "Content": ["xxxx {Platform}KFCASE -- NEWCASE xxxx\n",
-                  "CMDR: {CMDR} -- Platform: {Platform}\n",
-                  "System: {System} -- Planet: {Planet}\n",
-                  "Coordinates: {Coords}\n",
-                  "Type: {KFType}\n",
-                  "xxxxxxxx"]
+      "Content": [
+        "xxxx {Platform}KFCASE -- NEWCASE xxxx\n",
+        "CMDR: {CMDR} -- Platform: {Platform}\n",
+        "System: {System} -- Planet: {Planet}\n",
+        "Coordinates: {Coords}\n",
+        "Type: {KFType}\n",
+        "xxxxxxxx"
+      ],
+      "Type": "Case"
     }
-
   ]
 }

--- a/halpybot/commands/debug.py
+++ b/halpybot/commands/debug.py
@@ -32,6 +32,6 @@ async def cmd_clearboard(ctx: Context, args: List[str]):
 
 
 @Commands.command("fullboard")
-async def cmd_loadboard(ctx: Context, args: List[str]):
+async def cmd_fullboard(ctx: Context, args: List[str]):
     await ctx.bot.board.debug_full_board
     return await ctx.reply("Debug Full Data Loaded!")

--- a/halpybot/commands/debug.py
+++ b/halpybot/commands/debug.py
@@ -11,7 +11,7 @@ See license.md
 """
 from typing import List
 from ..packages.command import Commands
-from ..packages.models import Context
+from ..packages.models import Context, Platform
 
 
 @Commands.command("nextid")
@@ -35,3 +35,12 @@ async def cmd_clearboard(ctx: Context, args: List[str]):
 async def cmd_fullboard(ctx: Context, args: List[str]):
     await ctx.bot.board.debug_full_board
     return await ctx.reply("Debug Full Data Loaded!")
+
+
+@Commands.command("newcase")
+async def cmd_newcase(ctx: Context, args: List[str]):
+    cmdr = args[0]
+    plt = Platform(int(args[1])).name
+    sys = args[2]
+    case = await ctx.bot.board.add_case(client=cmdr, platform=plt, system=sys)
+    return await ctx.reply(f"New case started: Board ID {case.board_id}")

--- a/halpybot/commands/ping.py
+++ b/halpybot/commands/ping.py
@@ -86,7 +86,9 @@ async def cmd_serverstat(ctx: Context, args: List[str]):
     Aliases: n/a
     """
     try:
-        uri = "https://launcher-4586754895.elitedangerous.com/launcher-status/status.json"
+        uri = (
+            "https://launcher-4586754895.elitedangerous.com/launcher-status/status.json"
+        )
         responses = await web_get(uri)
     except aiohttp.ClientError as server_stat_error:
         logger.exception("Error in Elite Server Status lookup.")

--- a/halpybot/commands/ping.py
+++ b/halpybot/commands/ping.py
@@ -86,7 +86,7 @@ async def cmd_serverstat(ctx: Context, args: List[str]):
     Aliases: n/a
     """
     try:
-        uri = "https://hosting.zaonce.net/launcher-status/status.json"
+        uri = "https://launcher-4586754895.elitedangerous.com/launcher-status/status.json"
         responses = await web_get(uri)
     except aiohttp.ClientError as server_stat_error:
         logger.exception("Error in Elite Server Status lookup.")

--- a/halpybot/commands/ping.py
+++ b/halpybot/commands/ping.py
@@ -88,7 +88,6 @@ async def cmd_serverstat(ctx: Context, args: List[str]):
     try:
         uri = "https://hosting.zaonce.net/launcher-status/status.json"
         responses = await web_get(uri)
-        print(responses)
     except aiohttp.ClientError as server_stat_error:
         logger.exception("Error in Elite Server Status lookup.")
         await ctx.reply(

--- a/halpybot/commands/userinfo.py
+++ b/halpybot/commands/userinfo.py
@@ -15,7 +15,7 @@ from halpybot.packages.command.commandhandler import get_help_text
 from ..packages.seals import whois
 from ..packages.command import Commands
 from ..packages.checks import Require, Pup
-from ..packages.models import Context
+from ..packages.models import Context, Seal
 
 
 @Commands.command("whois")
@@ -37,7 +37,14 @@ async def cmd_whois(ctx: Context, args: List[str]):
             "is a DW2 Veteran and Founder Seal with registered CMDRs of Arf! Arf! Arf!, "
             "and has been involved with countless rescues."
         )
-    return await ctx.redirect(await whois(ctx.bot.engine, cmdr))
+    try:
+        seal: Seal = await whois(ctx.bot.engine, cmdr)
+    except KeyError:
+        return await ctx.reply("No registered user found by that name!")
+    return await ctx.reply(
+        f"CMDR {seal.name} has a Seal ID of {seal.seal_id}, registered on {seal.reg_date}{seal.dw2_history} {seal.aliases}"
+        f", and has been involved with {seal.case_num} rescues."
+    )
 
 
 @Commands.command("whoami")
@@ -51,4 +58,11 @@ async def cmd_whoami(ctx: Context, args: List[str]):
     Aliases: n/a
     """
     cmdr = ctx.sender
-    return await ctx.redirect(await whois(ctx.bot.engine, cmdr))
+    try:
+        seal: Seal = await whois(ctx.bot.engine, cmdr)
+    except KeyError:
+        return await ctx.redirect("No registered user found by that name!")
+    return await ctx.redirect(
+        f"CMDR {seal.name} has a Seal ID of {seal.seal_id}, registered on {seal.reg_date}{seal.dw2_history} {seal.aliases}"
+        f", and has been involved with {seal.case_num} rescues."
+    )

--- a/halpybot/commands/userinfo.py
+++ b/halpybot/commands/userinfo.py
@@ -7,15 +7,25 @@ All rights reserved.
 Licensed under the GNU General Public License
 See license.md
 """
-
 from typing import List
-
+from sqlalchemy.engine import Engine
 from halpybot.packages.command.commandhandler import get_help_text
-
 from ..packages.seals import whois
 from ..packages.command import Commands
 from ..packages.checks import Require, Pup
 from ..packages.models import Context, Seal
+
+
+async def whois_fetch(engine: Engine, cmdr: str):
+    """Fetch the details of the user requested by WHOIS"""
+    try:
+        seal: Seal = await whois(engine, cmdr)
+    except (KeyError, ValueError):
+        return "No registered user found by that name!"
+    return (
+        f"CMDR {seal.name} has a Seal ID of {seal.seal_id}, registered on {seal.reg_date}"
+        f"{seal.dw2_history} {seal.cmdrs}, and has been involved with {seal.case_num} rescues."
+    )
 
 
 @Commands.command("whois")
@@ -37,14 +47,7 @@ async def cmd_whois(ctx: Context, args: List[str]):
             "is a DW2 Veteran and Founder Seal with registered CMDRs of Arf! Arf! Arf!, "
             "and has been involved with countless rescues."
         )
-    try:
-        seal: Seal = await whois(ctx.bot.engine, cmdr)
-    except (KeyError, ValueError):
-        return await ctx.redirect("No registered user found by that name!")
-    return await ctx.redirect(
-        f"CMDR {seal.name} has a Seal ID of {seal.seal_id}, registered on {seal.reg_date}{seal.dw2_history} {seal.cmdrs}"
-        f", and has been involved with {seal.case_num} rescues."
-    )
+    return await ctx.redirect(await whois_fetch(ctx.bot.engine, cmdr))
 
 
 @Commands.command("whoami")
@@ -58,11 +61,4 @@ async def cmd_whoami(ctx: Context, args: List[str]):
     Aliases: n/a
     """
     cmdr = ctx.sender
-    try:
-        seal: Seal = await whois(ctx.bot.engine, cmdr)
-    except (KeyError, ValueError):
-        return await ctx.redirect("No registered user found by that name!")
-    return await ctx.redirect(
-        f"CMDR {seal.name} has a Seal ID of {seal.seal_id}, registered on {seal.reg_date}{seal.dw2_history} {seal.cmdrs}"
-        f", and has been involved with {seal.case_num} rescues."
-    )
+    return await ctx.redirect(await whois_fetch(ctx.bot.engine, cmdr))

--- a/halpybot/commands/userinfo.py
+++ b/halpybot/commands/userinfo.py
@@ -40,8 +40,8 @@ async def cmd_whois(ctx: Context, args: List[str]):
     try:
         seal: Seal = await whois(ctx.bot.engine, cmdr)
     except (KeyError, ValueError):
-        return await ctx.reply("No registered user found by that name!")
-    return await ctx.reply(
+        return await ctx.redirect("No registered user found by that name!")
+    return await ctx.redirect(
         f"CMDR {seal.name} has a Seal ID of {seal.seal_id}, registered on {seal.reg_date}{seal.dw2_history} {seal.cmdrs}"
         f", and has been involved with {seal.case_num} rescues."
     )

--- a/halpybot/commands/userinfo.py
+++ b/halpybot/commands/userinfo.py
@@ -42,7 +42,7 @@ async def cmd_whois(ctx: Context, args: List[str]):
     except (KeyError, ValueError):
         return await ctx.reply("No registered user found by that name!")
     return await ctx.reply(
-        f"CMDR {seal.name} has a Seal ID of {seal.seal_id}, registered on {seal.reg_date}{seal.dw2_history} {seal.aliases}"
+        f"CMDR {seal.name} has a Seal ID of {seal.seal_id}, registered on {seal.reg_date}{seal.dw2_history} {seal.cmdrs}"
         f", and has been involved with {seal.case_num} rescues."
     )
 
@@ -63,6 +63,6 @@ async def cmd_whoami(ctx: Context, args: List[str]):
     except (KeyError, ValueError):
         return await ctx.redirect("No registered user found by that name!")
     return await ctx.redirect(
-        f"CMDR {seal.name} has a Seal ID of {seal.seal_id}, registered on {seal.reg_date}{seal.dw2_history} {seal.aliases}"
+        f"CMDR {seal.name} has a Seal ID of {seal.seal_id}, registered on {seal.reg_date}{seal.dw2_history} {seal.cmdrs}"
         f", and has been involved with {seal.case_num} rescues."
     )

--- a/halpybot/commands/userinfo.py
+++ b/halpybot/commands/userinfo.py
@@ -39,7 +39,7 @@ async def cmd_whois(ctx: Context, args: List[str]):
         )
     try:
         seal: Seal = await whois(ctx.bot.engine, cmdr)
-    except KeyError:
+    except (KeyError, ValueError):
         return await ctx.reply("No registered user found by that name!")
     return await ctx.reply(
         f"CMDR {seal.name} has a Seal ID of {seal.seal_id}, registered on {seal.reg_date}{seal.dw2_history} {seal.aliases}"
@@ -60,7 +60,7 @@ async def cmd_whoami(ctx: Context, args: List[str]):
     cmdr = ctx.sender
     try:
         seal: Seal = await whois(ctx.bot.engine, cmdr)
-    except KeyError:
+    except (KeyError, ValueError):
         return await ctx.redirect("No registered user found by that name!")
     return await ctx.redirect(
         f"CMDR {seal.name} has a Seal ID of {seal.seal_id}, registered on {seal.reg_date}{seal.dw2_history} {seal.aliases}"

--- a/halpybot/packages/announcer/announcer.py
+++ b/halpybot/packages/announcer/announcer.py
@@ -129,7 +129,7 @@ class Announcer:
         # Create announcement objects and store them in dict
         for ann_type in self._config["AnnouncerType"]:
             self._announcements[ann_type["ID"]] = Announcement(
-                ann_type=ann_type["ID"],
+                case_type=ann_type["ID"],
                 name=ann_type["Name"],
                 description=ann_type["Description"],
                 channels=ann_type["Channels"],
@@ -168,7 +168,7 @@ class Announcement:
     """Create a new announceable object
 
     Args:
-        ann_type (str): Announcement reference code, used by API
+        case_type (str): Announcement reference code, used by API
         name (str): Name, for reference only
         description (str): Description of the announcement
         channels (list of str): channels the announcement is to be sent to
@@ -178,7 +178,7 @@ class Announcement:
         type (str): The Type of announcement (Case, Action, or Other)
     """
 
-    ann_type: str
+    case_type: str
     name: str
     description: str
     channels: List[str]

--- a/halpybot/packages/announcer/announcer.py
+++ b/halpybot/packages/announcer/announcer.py
@@ -11,6 +11,7 @@ See license.md
 
 import json
 from typing import List, Dict, Optional
+from attrs import define
 from ..edsm import (
     checklandmarks,
     get_nearby_system,
@@ -153,33 +154,26 @@ class Announcer:
             raise AnnouncementError(Exception) from announcement_exception
 
 
+@define
 class Announcement:
-    def __init__(
-        self,
-        ann_type: str,
-        name: str,
-        description: str,
-        channels: List[str],
-        edsm: Optional[int],
-        content: List[str],
-    ):
-        """Create a new announceable object
+    """Create a new announceable object
 
-        Args:
-            ann_type (str): Announcement reference code, used by API
-            name (str): Name, for reference only
-            description (str): Description of the announcement
-            channels (list of str): channels the announcement is to be sent to
-            edsm (int or Null): the announcement parameter we want to run
-                an EDSM system query on. none if Null.
-            content (list of str): lines to be sent in the announcement
-        """
-        self.ann_type = ann_type
-        self.name = name
-        self.description = description
-        self.channels = channels
-        self._edsm = edsm
-        self._content = "".join(content)
+    Args:
+        ann_type (str): Announcement reference code, used by API
+        name (str): Name, for reference only
+        description (str): Description of the announcement
+        channels (list of str): channels the announcement is to be sent to
+        edsm (int or Null): the announcement parameter we want to run
+            an EDSM system query on. none if Null.
+        content (list of str): lines to be sent in the announcement
+    """
+
+    ann_type: str
+    name: str
+    description: str
+    channels: List[str]
+    content: List[str]
+    edsm: Optional[int] = None
 
     async def format(self, args) -> str:
         """Format announcement in a ready-to-be-sent format
@@ -198,9 +192,9 @@ class Announcement:
         """
         if "System" in args.keys():
             args["System"] = await sys_cleaner(args["System"])
-        # Come on pylint
-        announcement = self._content.format(**args)
-        if self._edsm:
+        formatted_content = "".join(self.content)
+        announcement = formatted_content.format(**args)
+        if self.edsm:
             try:
                 announcement += await get_edsm_data(args)
             except ValueError:

--- a/halpybot/packages/announcer/announcer.py
+++ b/halpybot/packages/announcer/announcer.py
@@ -67,12 +67,11 @@ async def get_edsm_data(args: Dict, generalized: bool = False) -> Optional[str]:
         landmark, distance, direction = await checklandmarks(sys_name)
         # What we have is good, however, to make things look nice we need to flip the direction Drebin Style
         direction = cardinal_flip[direction]
-        if generalized:
-            return (
-                f"{distance} LY {direction} of {landmark}"
-                if generalized
-                else f"\nSystem exists in EDSM, {distance} LY {direction} of {landmark}."
-            )
+        return (
+            f"{distance} LY {direction} of {landmark}"
+            if generalized
+            else f"\nSystem exists in EDSM, {distance} LY {direction} of {landmark}."
+        )
     except NoNearbyEDSM:
         dssa, distance, direction = await checkdssa(sys_name)
         return (

--- a/halpybot/packages/announcer/announcer.py
+++ b/halpybot/packages/announcer/announcer.py
@@ -21,6 +21,7 @@ from ..edsm import (
     sys_cleaner,
     NoNearbyEDSM,
 )
+from ..models import Platform
 
 cardinal_flip = {
     "North": "South",
@@ -31,6 +32,14 @@ cardinal_flip = {
     "SW": "NE",
     "West": "East",
     "NW": "SE",
+}
+
+platform_shorts = {
+    Platform.ODYSSEY: "PCO",
+    Platform.XBOX: "XB",
+    Platform.PLAYSTATION: "PS",
+    Platform.LEGACY_HORIZONS: "PCH",
+    Platform.LIVE_HORIZONS: "PCL",
 }
 
 

--- a/halpybot/packages/announcer/announcer.py
+++ b/halpybot/packages/announcer/announcer.py
@@ -127,6 +127,7 @@ class Announcer:
                 channels=ann_type["Channels"],
                 edsm=ann_type["EDSM"],
                 content=ann_type["Content"],
+                type=ann_type["Type"],
             )
 
     async def announce(self, announcement: str, args: Dict, client):
@@ -166,6 +167,7 @@ class Announcement:
         edsm (int or Null): the announcement parameter we want to run
             an EDSM system query on. none if Null.
         content (list of str): lines to be sent in the announcement
+        type (str): The Type of announcement (Case, Action, or Other)
     """
 
     ann_type: str
@@ -174,6 +176,7 @@ class Announcement:
     channels: List[str]
     content: List[str]
     edsm: Optional[int] = None
+    type: Optional[str] = None
 
     async def format(self, args) -> str:
         """Format announcement in a ready-to-be-sent format

--- a/halpybot/packages/board/board.py
+++ b/halpybot/packages/board/board.py
@@ -112,6 +112,7 @@ class Board:
     @property
     def time_last_case(self) -> typing.Optional[DateTime]:
         """Time since the last case started"""
+        return self._last_case_time
 
     def _update_last_index(self):
         """Update the last case time index"""

--- a/halpybot/packages/board/board.py
+++ b/halpybot/packages/board/board.py
@@ -105,7 +105,7 @@ class Board:
         return next_id
 
     @property
-    def by_id(self) -> dict:
+    def by_id(self) -> typing.Dict[int, Case]:
         """Returns the cases_by_id dict"""
         return self._cases_by_id
 
@@ -133,7 +133,7 @@ class Board:
             return key in self._cases_by_id
         return False
 
-    async def add_case(self, client, platform: Platform, system) -> Case:
+    async def add_case(self, client: str, platform: Platform, system: str) -> Case:
         """Create a new Case given the client name"""
         async with self._modlock:
             new_id = self.open_rescue_id

--- a/halpybot/packages/board/board.py
+++ b/halpybot/packages/board/board.py
@@ -131,7 +131,7 @@ class Board:
         new_id = self.open_rescue_id
         case = Case(board_id=new_id, client_name=client, platform="PC", system="Delkar")
         self._last_case_time = now(tz="utc")
-        if case.board_name_ref() in self._case_alias_name:
+        if case.client_name in self._case_alias_name:
             raise ValueError("Case with Client Name Already Exists")
         async with self._modlock:
             self._cases_by_id[new_id] = case
@@ -143,7 +143,7 @@ class Board:
         """Modify an existing case"""
         async with self._modlock:
             current_case = case.board_id
-            current_client = case.board_name_ref()
+            current_client = case.client_name
             self._cases_by_id.pop(current_case)
             self._case_alias_name.pop(current_client)
             try:
@@ -156,7 +156,7 @@ class Board:
         """Delete a Case from the Board"""
         if isinstance(case, Case):
             board_id = case.board_id
-            client = case.board_name_ref()
+            client = case.client_name
             async with self._modlock:
                 self._cases_by_id.pop(board_id)
                 self._case_alias_name.pop(client)

--- a/halpybot/packages/checks/checks.py
+++ b/halpybot/packages/checks/checks.py
@@ -11,16 +11,19 @@ See license.md
 import functools
 from typing import List
 from loguru import logger
+from attr import dataclass
 from halpybot import config
 from ..models import User
 from ..database import test_database_connection, NoDatabaseConnection
 
 
+@dataclass
 class Permission:
-    def __init__(self, vhost: str, level: int, msg: str):
-        self.vhost = vhost
-        self.level = level
-        self.msg = msg
+    """Reference a specific permission level"""
+
+    vhost: str
+    level: int
+    msg: str
 
 
 Bot = Permission(

--- a/halpybot/packages/checks/checks.py
+++ b/halpybot/packages/checks/checks.py
@@ -11,13 +11,13 @@ See license.md
 import functools
 from typing import List
 from loguru import logger
-from attr import dataclass
+from attrs import define
 from halpybot import config
 from ..models import User
 from ..database import test_database_connection, NoDatabaseConnection
 
 
-@dataclass(frozen=True)
+@define(frozen=True)
 class Permission:
     """Reference a specific permission level"""
 

--- a/halpybot/packages/checks/checks.py
+++ b/halpybot/packages/checks/checks.py
@@ -17,7 +17,7 @@ from ..models import User
 from ..database import test_database_connection, NoDatabaseConnection
 
 
-@dataclass
+@dataclass(frozen=True)
 class Permission:
     """Reference a specific permission level"""
 

--- a/halpybot/packages/command/commandhandler.py
+++ b/halpybot/packages/command/commandhandler.py
@@ -312,12 +312,18 @@ def get_help_text(commandsfile, search_command: str):
     for command_dict in commandsfile.values():
         for command, details in command_dict.items():
             command = command.casefold()
-            if command == search_command or search_command in details["aliases"]:
+            if command == search_command or (
+                "aliases" in details and search_command in details["aliases"]
+            ):
                 arguments = details["arguments"]
-                aliases = details["aliases"]
+                aliases = (
+                    f"\nAliases: {', '.join(details['aliases'])}"
+                    if details["aliases"]
+                    else ""
+                )
                 usage = details["use"]
                 return (
-                    f"Use: {config.irc.command_prefix}{command} {arguments}\nAliases: {', '.join(aliases)}\n"
+                    f"Use: {config.irc.command_prefix}{command} {arguments} {aliases}\n"
                     f"{usage}"
                 )
     return None

--- a/halpybot/packages/edsm/edsm.py
+++ b/halpybot/packages/edsm/edsm.py
@@ -23,7 +23,7 @@ from loguru import logger
 import aiohttp
 import numpy as np
 import cattr
-from attr import dataclass, field
+from attrs import define, field
 from halpybot import config
 from ..models import Coordinates, Location
 from ..models import edsm_classes
@@ -61,7 +61,7 @@ class EDSMReturnError(EDSMLookupError):
     """
 
 
-@dataclass
+@define
 class EDSMQuery:
     """
     Formulate an EDSM Query and save the time the query was run.
@@ -71,7 +71,7 @@ class EDSMQuery:
     time: time()
 
 
-@dataclass
+@define
 class EDDBSystem:
     """
     EDDB system object
@@ -85,7 +85,7 @@ class EDDBSystem:
     coords: Coordinates
 
 
-@dataclass
+@define
 class GalaxySystem:
     """
     EDSM system object
@@ -236,7 +236,7 @@ class GalaxySystem:
         return sysname, dist
 
 
-@dataclass(frozen=True)
+@define(frozen=True)
 class Commander:
     """
     EDSM commander object
@@ -564,7 +564,7 @@ async def checkdssa(edsm_sys_name, cache_override: bool = False):
         )
 
 
-@dataclass
+@define
 class Diversion:
     """Format for finding Diversion systems"""
 

--- a/halpybot/packages/edsm/edsm.py
+++ b/halpybot/packages/edsm/edsm.py
@@ -61,7 +61,7 @@ class EDSMReturnError(EDSMLookupError):
     """
 
 
-@define
+@define(frozen=True)
 class EDSMQuery:
     """
     Formulate an EDSM Query and save the time the query was run.
@@ -71,7 +71,7 @@ class EDSMQuery:
     time: time()
 
 
-@define
+@define(frozen=True)
 class EDDBSystem:
     """
     EDDB system object
@@ -85,7 +85,7 @@ class EDDBSystem:
     coords: Coordinates
 
 
-@define
+@define(frozen=True)
 class GalaxySystem:
     """
     EDSM system object
@@ -564,7 +564,7 @@ async def checkdssa(edsm_sys_name, cache_override: bool = False):
         )
 
 
-@define
+@define(frozen=True)
 class Diversion:
     """Format for finding Diversion systems"""
 

--- a/halpybot/packages/edsm/edsm.py
+++ b/halpybot/packages/edsm/edsm.py
@@ -383,6 +383,8 @@ class Edsm:
         if self._landmarks:
             return self._landmarks
         landmark_target = Path() / "data" / "edsm" / "landmarks.json"
+        if not landmark_target.is_file():
+            raise FileNotFoundError
         landmarks = json.loads(landmark_target.read_text())
         self._landmarks = cattr.structure(landmarks, typing.List[GalaxySystem])
         return self._landmarks
@@ -393,6 +395,8 @@ class Edsm:
         if self._carriers:
             return self._carriers
         carrier_target = Path() / "data" / "edsm" / "dssa.json"
+        if not carrier_target.is_file():
+            raise FileNotFoundError
         carriers = json.loads(carrier_target.read_text())
         self._carriers = cattr.structure(carriers, typing.List[GalaxySystem])
         return self._carriers
@@ -403,6 +407,8 @@ class Edsm:
         if self._diversions:
             return self._diversions
         diversions_target = Path() / "data" / "edsm" / "diversions.json"
+        if not diversions_target.is_file():
+            raise FileNotFoundError
         loaded_diversions = json.loads(diversions_target.read_text())
         self._diversions = cattr.structure(loaded_diversions, typing.List[EDDBSystem])
         return self._diversions

--- a/halpybot/packages/ircclient/halpybot.py
+++ b/halpybot/packages/ircclient/halpybot.py
@@ -215,6 +215,14 @@ class HalpyBOT(pydle.Client, ListHandler):
             chlist.remove(channel)
             config.channels.channel_list = " ".join(chlist)
 
+    async def on_join(self, channel, user):
+        """Greet Case Users"""
+        await super().on_join(channel, user)
+        if channel not in config.channels.
+        # TODO: If new join member of a case, respond:
+        # await self.message(channel, f'{user} connected successfully.
+        # Welcome! Please wait for a dispatcher to respond to your case.')
+
 
 async def crash_notif(crashtype, condition):
     """

--- a/halpybot/packages/ircclient/halpybot.py
+++ b/halpybot/packages/ircclient/halpybot.py
@@ -18,6 +18,7 @@ from sqlalchemy import create_engine
 from halpybot import config
 from .. import utils
 from .. import notify
+from ..announcer import Announcer
 from ..board import Board
 from ._listsupport import ListHandler
 from ..command import Commands, CommandGroup
@@ -47,6 +48,7 @@ class HalpyBOT(pydle.Client, ListHandler):
         with open("data/help/commands.json", "r", encoding="UTF-8") as jsonfile:
             self._commandsfile = json.load(jsonfile)
         self._board = Board(id_range=10)
+        self._announcer = Announcer()
 
     @property
     def commandhandler(self):
@@ -72,6 +74,11 @@ class HalpyBOT(pydle.Client, ListHandler):
     def board(self):
         """Return the Case Board"""
         return self._board
+
+    @property
+    def announcer(self):
+        """Return the Announcer"""
+        return self._announcer
 
     @commandhandler.setter
     def commandhandler(self, handler: CommandGroup):

--- a/halpybot/packages/ircclient/halpybot.py
+++ b/halpybot/packages/ircclient/halpybot.py
@@ -218,9 +218,14 @@ class HalpyBOT(pydle.Client, ListHandler):
     async def on_join(self, channel, user):
         """Greet Case Users"""
         await super().on_join(channel, user)
-        # TODO: If new join member of a case, respond:
-        # await self.message(channel, f'{user} connected successfully.
-        # Welcome! Please wait for a dispatcher to respond to your case.')
+        for board_id, case in self.board.by_id.items():
+            if user in (case.irc_nick, case.client_name):
+                return await self.message(
+                    channel,
+                    f"{user} connected successfully. Welcome! Please "
+                    f"wait for a dispatcher to respond to your case. "
+                    f"(Case ID: {board_id})",
+                )
 
 
 async def crash_notif(crashtype, condition):

--- a/halpybot/packages/ircclient/halpybot.py
+++ b/halpybot/packages/ircclient/halpybot.py
@@ -218,7 +218,6 @@ class HalpyBOT(pydle.Client, ListHandler):
     async def on_join(self, channel, user):
         """Greet Case Users"""
         await super().on_join(channel, user)
-        if channel not in config.channels.
         # TODO: If new join member of a case, respond:
         # await self.message(channel, f'{user} connected successfully.
         # Welcome! Please wait for a dispatcher to respond to your case.')

--- a/halpybot/packages/models/__init__.py
+++ b/halpybot/packages/models/__init__.py
@@ -12,6 +12,7 @@ from .edsm_classes import Coordinates, Location, SystemInfo
 from .user import User, UserError, NoUserFound
 from .context import Context
 from .case import Case
+from .seal import Seal
 
 __all__ = [
     "Context",
@@ -22,4 +23,5 @@ __all__ = [
     "UserError",
     "NoUserFound",
     "Case",
+    "Seal",
 ]

--- a/halpybot/packages/models/__init__.py
+++ b/halpybot/packages/models/__init__.py
@@ -11,6 +11,7 @@ See license.md
 from .edsm_classes import Coordinates, Location, SystemInfo
 from .user import User, UserError, NoUserFound
 from .context import Context
+from .case import Case
 
 __all__ = [
     "Context",
@@ -20,4 +21,5 @@ __all__ = [
     "SystemInfo",
     "UserError",
     "NoUserFound",
+    "Case",
 ]

--- a/halpybot/packages/models/__init__.py
+++ b/halpybot/packages/models/__init__.py
@@ -11,7 +11,7 @@ See license.md
 from .edsm_classes import Coordinates, Location, SystemInfo
 from .user import User, UserError, NoUserFound
 from .context import Context
-from .case import Case
+from .case import Case, Platform, KFCoords, Status
 from .seal import Seal
 
 __all__ = [
@@ -23,5 +23,8 @@ __all__ = [
     "UserError",
     "NoUserFound",
     "Case",
+    "Platform",
+    "KFCoords",
+    "Status",
     "Seal",
 ]

--- a/halpybot/packages/models/case.py
+++ b/halpybot/packages/models/case.py
@@ -22,7 +22,8 @@ class Case:
     system: str
     platform: str
     board_id: int
-    creation_time = updated_time = pendulum.now(tz="utc")
+    creation_time: pendulum.DateTime = field(factory=lambda: pendulum.now(tz="utc"))
+    updated_time: pendulum.DateTime = field(factory=lambda: pendulum.now(tz="utc"))
     active: bool = True
     # Filled As Case Continues
     dispatchers: list = field(factory=list)

--- a/halpybot/packages/models/case.py
+++ b/halpybot/packages/models/case.py
@@ -31,7 +31,7 @@ class Status(Enum):
     DELAYED = 2
 
 
-@define
+@define(frozen=True)
 class KFCoords:
     """KingFisher Coordinate Object"""
 

--- a/halpybot/packages/models/case.py
+++ b/halpybot/packages/models/case.py
@@ -10,7 +10,6 @@ See license.md
 from typing import Optional
 from enum import Enum
 from attrs import define, field
-from attr import dataclass
 import pendulum
 
 
@@ -32,7 +31,7 @@ class Status(Enum):
     DELAYED = 2
 
 
-@dataclass
+@define
 class KFCoords:
     """KingFisher Coordinate Object"""
 

--- a/halpybot/packages/models/case.py
+++ b/halpybot/packages/models/case.py
@@ -8,8 +8,36 @@ Licensed under the GNU General Public License
 See license.md
 """
 from typing import Optional
+from enum import Enum
 from attrs import define, field
+from attr import dataclass
 import pendulum
+
+
+class Platform(Enum):
+    """Storing Platform References"""
+
+    ODYSSEY = 1
+    XBOX = 2
+    PLAYSTATION = 3
+    LEGACY_HORIZONS = 4
+    LIVE_HORIZONS = 5
+
+
+class Status(Enum):
+    """Saving Case Status"""
+
+    ACTIVE = 0
+    CLOSED = 1
+    DELAYED = 2
+
+
+@dataclass
+class KFCoords:
+    """KingFisher Coordinate Object"""
+
+    x: float
+    y: float
 
 
 @define
@@ -20,17 +48,16 @@ class Case:
     # Da Mandatories
     client_name: str
     system: str
-    platform: str
+    platform: Platform
     board_id: int
     creation_time: pendulum.DateTime = field(factory=lambda: pendulum.now(tz="utc"))
     updated_time: pendulum.DateTime = field(factory=lambda: pendulum.now(tz="utc"))
-    active: bool = True
+    status: Status = Status.ACTIVE
     # Filled As Case Continues
     dispatchers: list = field(factory=list)
     responders: list = field(factory=list)
     case_notes: list = field(factory=list)
-    case_status: Optional[str] = None
-    closed_to: Optional[str] = None
+    closed_to: Optional[int] = None
 
     # Da Optionalz
     irc_nick: Optional[str] = None
@@ -41,9 +68,4 @@ class Case:
 
     # For Kingfisher Cases
     planet: Optional[str] = None
-    pcoords: Optional[str] = None
-
-
-# TODOs:
-# How do we define platforms, Case Status, coords, etc.?
-# Can we define our lists more specifically?
+    pcoords: Optional[KFCoords] = None

--- a/halpybot/packages/models/case.py
+++ b/halpybot/packages/models/case.py
@@ -1,0 +1,54 @@
+"""
+case.py - The Case Object
+
+Copyright (c) The Hull Seals,
+All rights reserved.
+
+Licensed under the GNU General Public License
+See license.md
+"""
+from typing import Optional
+from attrs import define, field
+import pendulum
+
+
+@define
+class Case:
+    """The Case Object - Tracking All The Things!"""
+
+    # All Cases
+    # Da Mandatories
+    client_name: str
+    system: str
+    platform: str
+    board_id: int
+    creation_time = updated_time = pendulum.now(tz="utc")
+    active: bool = True
+    # Filled As Case Continues
+    dispatchers: list = field(factory=list)
+    responders: list = field(factory=list)
+    case_notes: list = field(factory=list)
+    case_status: Optional[str] = None
+    closed_to: Optional[str] = None
+
+    # Da Optionalz
+    irc_nick: Optional[str] = None
+
+    # For Seal Cases
+    hull_percent: Optional[int] = None
+    canopy_broken: Optional[bool] = None
+
+    # For Kingfisher Cases
+    planet: Optional[str] = None
+    pcoords: Optional[str] = None
+
+    def board_name_ref(self):
+        """Return how we are referring to the Client's name"""
+        if self.irc_nick:
+            return self.irc_nick
+        return self.client_name
+
+
+# TODOs:
+# How do we define platforms, Case Status, coords, etc.?
+# Can we define our lists more specifically?

--- a/halpybot/packages/models/case.py
+++ b/halpybot/packages/models/case.py
@@ -43,12 +43,6 @@ class Case:
     planet: Optional[str] = None
     pcoords: Optional[str] = None
 
-    def board_name_ref(self):
-        """Return how we are referring to the Client's name"""
-        if self.irc_nick:
-            return self.irc_nick
-        return self.client_name
-
 
 # TODOs:
 # How do we define platforms, Case Status, coords, etc.?

--- a/halpybot/packages/models/edsm_classes.py
+++ b/halpybot/packages/models/edsm_classes.py
@@ -17,7 +17,7 @@ from typing import Optional
 from attrs import define
 
 
-@define
+@define(frozen=True)
 class Coordinates:
     """EDSM object coordinates dictionary"""
 
@@ -26,7 +26,7 @@ class Coordinates:
     z: float
 
 
-@define
+@define(frozen=True)
 class SystemInfo:
     """EDSM system information dictionary"""
 
@@ -39,7 +39,7 @@ class SystemInfo:
     economy: str
 
 
-@define
+@define(frozen=True)
 class Location:
     """EDSM location object"""
 
@@ -48,7 +48,7 @@ class Location:
     time: Optional[str]
 
 
-@define
+@define(frozen=True)
 class Commander:
     """The Commander keys we care about"""
 
@@ -58,7 +58,7 @@ class Commander:
     date: Optional[str]
 
 
-@define
+@define(frozen=True)
 class Galaxy:
     """Galaxy Keys we care about"""
 

--- a/halpybot/packages/models/edsm_classes.py
+++ b/halpybot/packages/models/edsm_classes.py
@@ -14,10 +14,10 @@ See license.md
 """
 
 from typing import Optional
-from attr import dataclass
+from attrs import define
 
 
-@dataclass
+@define
 class Coordinates:
     """EDSM object coordinates dictionary"""
 
@@ -26,7 +26,7 @@ class Coordinates:
     z: float
 
 
-@dataclass
+@define
 class SystemInfo:
     """EDSM system information dictionary"""
 
@@ -39,7 +39,7 @@ class SystemInfo:
     economy: str
 
 
-@dataclass
+@define
 class Location:
     """EDSM location object"""
 
@@ -48,7 +48,7 @@ class Location:
     time: Optional[str]
 
 
-@dataclass
+@define
 class Commander:
     """The Commander keys we care about"""
 
@@ -58,7 +58,7 @@ class Commander:
     date: Optional[str]
 
 
-@dataclass
+@define
 class Galaxy:
     """Galaxy Keys we care about"""
 

--- a/halpybot/packages/models/seal.py
+++ b/halpybot/packages/models/seal.py
@@ -17,10 +17,11 @@ class Seal:
 
     name: str
     seal_id: int
+    case_num: int
+    cmdrs: Optional[List[str]]
+    irc_aliases: Optional[List[str]]
     reg_date: str
     dw2: bool
-    aliases: Optional[List[str]]
-    case_num: int
 
     @property
     def dw2_history(self):

--- a/halpybot/packages/models/seal.py
+++ b/halpybot/packages/models/seal.py
@@ -1,0 +1,30 @@
+"""
+seal.py - Who are you, again?
+
+Copyright (c) The Hull Seals,
+All rights reserved.
+
+Licensed under the GNU General Public License
+See license.md
+"""
+from typing import Optional, List
+from attr import dataclass
+
+
+@dataclass
+class Seal:
+    """Define our Seal"""
+
+    name: str
+    seal_id: int
+    reg_date: str
+    dw2: bool
+    aliases: Optional[List[str]]
+    case_num: int
+
+    @property
+    def dw2_history(self):
+        """Is the Seal a DW2 vet?"""
+        if self.dw2:
+            return ", is a DW2 Veteran and Founder Seal with registered CMDRs of"
+        return ", with registered CMDRs of"

--- a/halpybot/packages/models/seal.py
+++ b/halpybot/packages/models/seal.py
@@ -11,7 +11,7 @@ from typing import Optional, List
 from attrs import define
 
 
-@define
+@define(frozen=True)
 class Seal:
     """Define our Seal"""
 

--- a/halpybot/packages/models/seal.py
+++ b/halpybot/packages/models/seal.py
@@ -8,10 +8,10 @@ Licensed under the GNU General Public License
 See license.md
 """
 from typing import Optional, List
-from attr import dataclass
+from attrs import define
 
 
-@dataclass
+@define
 class Seal:
     """Define our Seal"""
 

--- a/halpybot/packages/models/user.py
+++ b/halpybot/packages/models/user.py
@@ -22,7 +22,7 @@ See license.md
 
 from __future__ import annotations
 from typing import Optional, Set, TYPE_CHECKING
-from attr import dataclass
+from attrs import define
 import cattr
 
 if TYPE_CHECKING:
@@ -41,7 +41,7 @@ class NoUserFound(UserError):
     """
 
 
-@dataclass(frozen=True)
+@define(frozen=True)
 class User:
     """IRC User info
 

--- a/halpybot/packages/notify/notify.py
+++ b/halpybot/packages/notify/notify.py
@@ -77,7 +77,7 @@ async def subscribe(topic, endpoint):
 
     """
 
-    mail = r"^(\w|\.|\_|\-)+[@](\w|\_|\-|\.)+[.]\w{2,24}$"
+    mail = r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
     sms = r"^\+?[1-9]\d{1,14}$"
     protocol = None
 

--- a/halpybot/packages/seals/userinfo.py
+++ b/halpybot/packages/seals/userinfo.py
@@ -24,11 +24,9 @@ async def whois(engine: Engine, subject):
     """
     connection = engine.raw_connection()
     args = (subject, 0, 0, 0, 0, 0, 0, 0)
-    cursor_obj = connection.cursor()
-    cursor_obj.callproc("spWhoIs", args)
-    result = list(cursor_obj.fetchall())
-    cursor_obj.close()
-    connection.close()
+    with connection.cursor() as cursor_obj:
+        cursor_obj.callproc("spWhoIs", args)
+        result = list(cursor_obj.fetchall())
     if not result:
         raise KeyError("No Results Given")
     for res in result:

--- a/halpybot/packages/seals/userinfo.py
+++ b/halpybot/packages/seals/userinfo.py
@@ -34,6 +34,8 @@ async def whois(engine: Engine, subject):
         raise KeyError("No Results Given")
     for res in result:
         u_id, u_cases, u_name, u_regdate, u_dw2 = res
+        if u_id is None:
+            raise ValueError
         seal = Seal(
             name=subject,
             seal_id=u_id,

--- a/halpybot/packages/seals/userinfo.py
+++ b/halpybot/packages/seals/userinfo.py
@@ -8,7 +8,7 @@ Licensed under the GNU General Public License
 See license.md
 """
 from sqlalchemy.engine import Engine
-from ..database import NoDatabaseConnection
+from ..models import Seal
 
 
 async def whois(engine: Engine, subject):
@@ -19,42 +19,27 @@ async def whois(engine: Engine, subject):
         subject (str): The Seal's name being searched
 
     Returns:
-        (str): The details about the Seal, or an error string if not found.
+        (Seal): The Seal object
 
     """
-    # Set default values
-    u_id, u_cases, u_name, u_regdate, u_distant_worlds, u_distant_worlds_2 = (
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-    )
     connection = engine.raw_connection()
-    try:
-        args = (subject, 0, 0, 0, 0, 0, 0)
-        cursor_obj = connection.cursor()
-        cursor_obj.callproc("spWhoIs", args)
-        result = list(cursor_obj.fetchall())
-        cursor_obj.close()
-        connection.commit()
-    except NoDatabaseConnection:
-        return "Error searching user."
-    finally:
-        connection.close()
+    args = (subject, 0, 0, 0, 0, 0, 0)
+    cursor_obj = connection.cursor()
+    cursor_obj.callproc("spWhoIs", args)
+    result = list(cursor_obj.fetchall())
+    cursor_obj.close()
+    connection.commit()
+    connection.close()
+    if not result:
+        raise KeyError("No Results Given")
     for res in result:
-        u_id, u_cases, u_name, u_regdate, u_distant_worlds = res
-        if u_distant_worlds == 1:
-            u_distant_worlds_2 = (
-                ", is a DW2 Veteran and Founder Seal with registered CMDRs of"
-            )
-        else:
-            u_distant_worlds_2 = ", with registered CMDRs of"
-
-    if u_id is None:
-        return "No registered user found by that name!"
-    return (
-        f"CMDR {subject} has a Seal ID of {u_id}, registered on {u_regdate}{u_distant_worlds_2} {u_name}"
-        f", and has been involved with {u_cases} rescues."
-    )
+        u_id, u_cases, u_name, u_regdate, u_dw2 = res
+        seal = Seal(
+            name=subject,
+            seal_id=u_id,
+            reg_date=u_regdate,
+            dw2=u_dw2,
+            aliases=u_name,
+            case_num=u_cases,
+        )
+        return seal

--- a/halpybot/packages/seals/userinfo.py
+++ b/halpybot/packages/seals/userinfo.py
@@ -33,7 +33,6 @@ async def whois(engine: Engine, subject):
     if not result:
         raise KeyError("No Results Given")
     for res in result:
-        print(res)
         u_id, u_cases, u_name, u_aliases, u_regdate, u_dw2 = res
         if u_id is None:
             raise ValueError

--- a/halpybot/packages/seals/userinfo.py
+++ b/halpybot/packages/seals/userinfo.py
@@ -28,7 +28,6 @@ async def whois(engine: Engine, subject):
     cursor_obj.callproc("spWhoIs", args)
     result = list(cursor_obj.fetchall())
     cursor_obj.close()
-    connection.commit()
     connection.close()
     if not result:
         raise KeyError("No Results Given")

--- a/halpybot/packages/seals/userinfo.py
+++ b/halpybot/packages/seals/userinfo.py
@@ -23,7 +23,7 @@ async def whois(engine: Engine, subject):
 
     """
     connection = engine.raw_connection()
-    args = (subject, 0, 0, 0, 0, 0, 0)
+    args = (subject, 0, 0, 0, 0, 0, 0, 0)
     cursor_obj = connection.cursor()
     cursor_obj.callproc("spWhoIs", args)
     result = list(cursor_obj.fetchall())
@@ -33,15 +33,16 @@ async def whois(engine: Engine, subject):
     if not result:
         raise KeyError("No Results Given")
     for res in result:
-        u_id, u_cases, u_name, u_regdate, u_dw2 = res
+        print(res)
+        u_id, u_cases, u_name, u_aliases, u_regdate, u_dw2 = res
         if u_id is None:
             raise ValueError
-        seal = Seal(
+        return Seal(
             name=subject,
             seal_id=u_id,
             reg_date=u_regdate,
             dw2=u_dw2,
-            aliases=u_name,
+            cmdrs=u_name,
+            irc_aliases=u_aliases,
             case_num=u_cases,
         )
-        return seal

--- a/halpybot/server/__init__.py
+++ b/halpybot/server/__init__.py
@@ -9,7 +9,7 @@ See license.md
 """
 
 from .server import APIConnector
-from .server_announcer import MainAnnouncer
+from .server_announcer import announce
 from .rank_change import tail
 
-__all__ = ["APIConnector", "MainAnnouncer", "tail"]
+__all__ = ["APIConnector", "announce", "tail"]

--- a/halpybot/server/auth.py
+++ b/halpybot/server/auth.py
@@ -51,7 +51,6 @@ def authenticate():
             msg = "".join(
                 msg.split()
             )  # Remove all whitespace for the purpose of ensuring identical inputs to HMAC
-
             mac = get_hmac(msg)
             check = hmac.new(
                 bytes(config.api_connector.key.get_secret_value(), "utf8"),

--- a/halpybot/server/rank_change.py
+++ b/halpybot/server/rank_change.py
@@ -15,6 +15,7 @@ from sqlalchemy import text
 from .server import APIConnector
 from .auth import authenticate
 from ..packages.database import NoDatabaseConnection
+from ..packages.ircclient import HalpyBOT
 
 routes = web.RouteTableDef()
 
@@ -34,7 +35,7 @@ async def tail(request):
     Raises:
         HTTPOK or HTTPServiceUnavailable
     """
-    botclient = request.app["botclient"]
+    botclient: HalpyBOT = request.app["botclient"]
     if request.body_exists:
         request = await request.json()
     # Parse arguments
@@ -42,7 +43,7 @@ async def tail(request):
     subject = request["subject"]
     try:
         vhost = f"{subject}.{rank}.hullseals.space"
-        with botclient.connect() as database_connection:
+        with botclient.engine.connect() as database_connection:
             result = database_connection.execute(
                 text(
                     "SELECT nick FROM ircDB.anope_db_NickAlias WHERE nc = :subject_name;"

--- a/halpybot/server/server.py
+++ b/halpybot/server/server.py
@@ -17,6 +17,7 @@ from aiohttp import web
 from aiohttp.web_exceptions import HTTPBadRequest, HTTPMethodNotAllowed, HTTPNotFound
 from halpybot import __version__, DEFAULT_USER_AGENT
 from halpybot import config
+from ..packages.ircclient import HalpyBOT
 
 
 routes = web.RouteTableDef()
@@ -104,7 +105,7 @@ async def server_root(request):
         sha = f" build {sha}"
     except git.InvalidGitRepositoryError:
         sha = ""
-    botclient = request.app["botclient"]
+    botclient: HalpyBOT = request.app["botclient"]
     server_status_nick = botclient.nickname
     if server_status_nick == "<unregistered>":
         server_status_nick = "Not Connected"

--- a/halpybot/server/server_announcer.py
+++ b/halpybot/server/server_announcer.py
@@ -11,7 +11,8 @@ See license.md
 
 from typing import Dict
 from aiohttp import web
-from ..packages.announcer import Announcer, AnnouncementError
+from ..packages.announcer import AnnouncementError
+from ..packages.ircclient import HalpyBOT
 from .server import APIConnector
 from .auth import authenticate
 
@@ -33,14 +34,14 @@ async def announce(request):
     Raises:
         HTTPOk or HTTPInternalServerError
     """
-    botclient = request.app["botclient"]
+    botclient: HalpyBOT = request.app["botclient"]
     if request.body_exists:
         request = await request.json()
     # Parse arguments
     announcement = request["type"]
     args: Dict = request["parameters"]
     try:
-        await MainAnnouncer.announce(
+        await botclient.announcer.announce(
             announcement=announcement, args=args, client=botclient
         )
         raise web.HTTPOk
@@ -48,5 +49,4 @@ async def announce(request):
         raise web.HTTPInternalServerError from AnnouncementError
 
 
-MainAnnouncer = Announcer()
 APIConnector.add_routes(routes)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,23 +15,23 @@ python = ">=3.8,<3.10"
 pydle = {extras = ["sasl"], version = "^1.0.1"}
 mysqlclient = "^2.1.1"
 numpy = "^1.24.1"
-boto3 = "^1.26.55"
+boto3 = "^1.26.84"
 aiohttp = "^3.8.3"
 gitpython = "^3.1.30"
 requests = "^2.28.2"
 pyperclip = "^1.8.2"
-tqdm = "^4.64.1"
+tqdm = "^4.65.0"
 attrs = "^22.2.0"
 cattrs = "^22.2.0"
 loguru = "^0.6.0"
 pydantic = {extras = ["dotenv"], version = "^1.10.2"}
-sqlalchemy = "^1.4.46"
+sqlalchemy = "^2.0.4"
 beautifulsoup4 = "^4.11.1"
 lxml = "^4.9.2"
 pendulum = "^2.1.2"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^7.2.1"
+pytest = "^7.2.2"
 pytest-httpserver = "^1.0.6"
 pytest-asyncio = "^0.20.3"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,12 +14,19 @@ if os.getcwd().endswith("tests"):
     os.chdir("..")
 
 # noinspection PyUnresolvedReferences
-from halpybot import commands
+from halpybot import commands, config
 from .fixtures.mock_halpy import TestBot
 
 
 @pytest.fixture()
-async def bot_fx():
+async def bot_fx() -> TestBot:
     """Create a fixture that represents the bot"""
     test_bot = TestBot(nickname="HalpyTest[BOT]")
     return test_bot
+
+
+@pytest.fixture()
+async def db_engine(bot_fx: bot_fx):
+    """Create a db_engine fixture"""
+    config.offline_mode.enabled = False
+    return bot_fx.engine

--- a/tests/fixtures/mock_halpy.py
+++ b/tests/fixtures/mock_halpy.py
@@ -157,3 +157,8 @@ class TestBot(HalpyBOT):
         raise RuntimeWarning(
             "Connection to a server disallowed in instances of the mock bot."
         )
+
+    @property
+    def engine(self):
+        """Database Connection Engine"""
+        return self._engine

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -536,39 +536,41 @@ async def test_drillcb_unauth(bot_fx):
     }
 
 
-# FIXME
-# @pytest.mark.asyncio
-# async def test_go_valid(bot_fx):
-#     """Test the GO command"""
-#     await Commands.invoke_from_message(
-#         bot=bot_fx,
-#         channel="#bot-test",
-#         sender="generic_seal",
-#         message=f"{config.irc.command_prefix}go some_pup",
-#     )
-#     assert bot_fx.sent_messages[0] == {
-#         "message": "some_pup: You're up.",
-#         "target": "#bot-test",
-#     }
-#
-#
-# @pytest.mark.asyncio
-# async def test_go_guest(bot_fx):
-#     """Test the GO command"""
-#     await Commands.invoke_from_message(
-#         bot=bot_fx,
-#         channel="#bot-test",
-#         sender="generic_seal",
-#         message=f"{config.irc.command_prefix}go guest_user",
-#     )
-#     assert bot_fx.sent_messages[0] == {
-#         "message": "generic_seal: guest_user is not identified as a trained seal. Have them check their IRC setup?",
-#         "target": "#bot-test",
-#     }
-#     assert bot_fx.sent_messages[1] == {
-#         "message": "guest_user: You're up.",
-#         "target": "#bot-test",
-#     }
+# TODO: Stop Touching Database
+@pytest.mark.asyncio
+async def test_go_valid(bot_fx):
+    """Test the GO command"""
+    await bot_fx.facts.fetch_facts(bot_fx.engine, preserve_current=True)
+    await Commands.invoke_from_message(
+        bot=bot_fx,
+        channel="#bot-test",
+        sender="generic_seal",
+        message=f"{config.irc.command_prefix}go some_pup",
+    )
+    assert bot_fx.sent_messages[0] == {
+        "message": "some_pup: You're up.",
+        "target": "#bot-test",
+    }
+
+
+@pytest.mark.asyncio
+async def test_go_guest(bot_fx):
+    """Test the GO command"""
+    await bot_fx.facts.fetch_facts(bot_fx.engine, preserve_current=True)
+    await Commands.invoke_from_message(
+        bot=bot_fx,
+        channel="#bot-test",
+        sender="generic_seal",
+        message=f"{config.irc.command_prefix}go guest_user",
+    )
+    assert bot_fx.sent_messages[0] == {
+        "message": "generic_seal: guest_user is not identified as a trained seal. Have them check their IRC setup?",
+        "target": "#bot-test",
+    }
+    assert bot_fx.sent_messages[1] == {
+        "message": "guest_user: You're up.",
+        "target": "#bot-test",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -195,7 +195,7 @@ async def test_help_specific(bot_fx):
         message=f"{config.irc.command_prefix}help ping",
     )
     assert bot_fx.sent_messages[0] == {
-        "message": f"Use: {config.irc.command_prefix}ping \nAliases: \nCheck to see if the bot is responding to commands.",
+        "message": f"Use: {config.irc.command_prefix}ping  \nCheck to see if the bot is responding to commands.",
         "target": "#bot-test",
     }
 
@@ -210,11 +210,11 @@ async def test_help_multiple(bot_fx):
         message=f"{config.irc.command_prefix}help ping dssa",
     )
     assert bot_fx.sent_messages[0] == {
-        "message": f"Use: {config.irc.command_prefix}ping \nAliases: \nCheck to see if the bot is responding to commands.",
+        "message": f"Use: {config.irc.command_prefix}ping  \nCheck to see if the bot is responding to commands.",
         "target": "#bot-test",
     }
     assert bot_fx.sent_messages[1] == {
-        "message": f"Use: {config.irc.command_prefix}dssa [EDSM Valid Location]\nAliases: \nCheck for the closest DSSA carrier to a given location.",
+        "message": f"Use: {config.irc.command_prefix}dssa [EDSM Valid Location] \nCheck for the closest DSSA carrier to a given location.",
         "target": "#bot-test",
     }
 
@@ -336,7 +336,7 @@ async def test_say_no_args(bot_fx):
         message=f"{config.irc.command_prefix}say",
     )
     assert bot_fx.sent_messages[0] == {
-        "message": f"Use: {config.irc.command_prefix}say [channel] [text]\nAliases: \nMake the Bot say something",
+        "message": f"Use: {config.irc.command_prefix}say [channel] [text] \nMake the Bot say something",
         "target": "some_cyber",
     }
 
@@ -366,7 +366,7 @@ async def test_whois_empty(bot_fx):
         message=f"{config.irc.command_prefix}whois",
     )
     assert bot_fx.sent_messages[0] == {
-        "message": f"Use: {config.irc.command_prefix}whois [name]\nAliases: \nCheck the user information for registered name. Must be a registered user, and run in DMs with HalpyBOT.",
+        "message": f"Use: {config.irc.command_prefix}whois [name] \nCheck the user information for registered name. Must be a registered user, and run in DMs with HalpyBOT.",
         "target": "some_admin",
     }
 
@@ -428,7 +428,7 @@ async def test_drill_empty(bot_fx):
         message=f"{config.irc.command_prefix}drillcase",
     )
     assert bot_fx.sent_messages[0] == {
-        "message": f"Use: {config.irc.command_prefix}drillcase [cmdr], [platform], [system], [hull]\nAliases: \nStarts a new Drill Case, separated by Commas",
+        "message": f"Use: {config.irc.command_prefix}drillcase [cmdr], [platform], [system], [hull] \nStarts a new Drill Case, separated by Commas",
         "target": "#bot-test",
     }
 
@@ -443,7 +443,7 @@ async def test_drillkf_empty(bot_fx):
         message=f"{config.irc.command_prefix}drillkfcase",
     )
     assert bot_fx.sent_messages[0] == {
-        "message": f"Use: {config.irc.command_prefix}drillkfcase [cmdr], [platform], [system], [planet], [coords], [type]\nAliases: \nStarts a new Drill Kingfisher Case, separated by Commas",
+        "message": f"Use: {config.irc.command_prefix}drillkfcase [cmdr], [platform], [system], [planet], [coords], [type] \nStarts a new Drill Kingfisher Case, separated by Commas",
         "target": "#bot-test",
     }
 
@@ -458,7 +458,7 @@ async def test_drillcb_empty(bot_fx):
         message=f"{config.irc.command_prefix}drillcbcase",
     )
     assert bot_fx.sent_messages[0] == {
-        "message": f"Use: {config.irc.command_prefix}drillcbcase [cmdr], [platform], [system], [hull], [cansynth], [o2]\nAliases: \nStarts a new Drill CB Case, separated by Commas",
+        "message": f"Use: {config.irc.command_prefix}drillcbcase [cmdr], [platform], [system], [hull], [cansynth], [o2] \nStarts a new Drill CB Case, separated by Commas",
         "target": "#bot-test",
     }
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -11,6 +11,7 @@ See license.md
 import time
 import pytest
 from halpybot.packages.database import test_database_connection
+from halpybot import config
 
 
 @pytest.mark.asyncio
@@ -18,6 +19,7 @@ async def test_db(bot_fx):
     """Test the Database Latency.
 
     If it's above 15, the connection is unusable."""
+    config.offline_mode.enabled = False
     start = time.time()
     connection = await test_database_connection(bot_fx.engine)
     final = round(connection - start, 2)

--- a/tests/test_seals.py
+++ b/tests/test_seals.py
@@ -11,6 +11,8 @@ Testing will always DISABLE offline mode. You must have access to a Seal-type DB
 """
 
 import pytest
+
+from halpybot.packages.models import Seal
 from halpybot.packages.seals import whois
 from halpybot import config
 
@@ -18,29 +20,17 @@ config.offline_mode.enabled = False
 
 
 @pytest.mark.asyncio
-async def test_egg_whois(bot_fx):
-    """Test the WHOIS reply for the fun name"""
-    user = await whois(bot_fx.engine, "HalpyBOT")
-    user = user[: len(user) // 2]
-    assert (
-        user
-        == "CMDR HalpyBOT has a Seal ID of 235, registered on 2019-12-20, is a DW2 Veteran and Founder Seal "
-    )
-
-
-@pytest.mark.asyncio
 async def test_good_whois(bot_fx):
     """Test the WHOIS reply for a valid user"""
     user = await whois(bot_fx.engine, "rik079")
-    user = user[: len(user) // 3]
-    assert user == "CMDR rik079 has a Seal ID of 400, registered on 2020-01-15, with r"
+    assert isinstance(user, Seal)
 
 
 @pytest.mark.asyncio
 async def test_bad_whois(bot_fx):
     """Test the WHOIS reply for a valid user"""
-    user = await whois(bot_fx.engine, "blargnet")
-    assert user == "No registered user found by that name!"
+    with pytest.raises(ValueError):
+        await whois(bot_fx.engine, "blargnet")
 
 
 @pytest.mark.asyncio
@@ -48,6 +38,6 @@ async def test_offline_whois(bot_fx):
     """Test that the WHOIS system responds properly in ONLINE mode"""
     prev_value = config.offline_mode.enabled
     config.offline_mode.enabled = True
-    user = await whois(bot_fx.engine, "ThisCMDRDoesntExist")
-    assert user == "No registered user found by that name!"
+    with pytest.raises(ValueError):
+        await whois(bot_fx.engine, "ThisCMDRDoesntExist")
     config.offline_mode.enabled = prev_value

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,14 +7,16 @@ All rights reserved.
 Licensed under the GNU General Public License
 See license.md
 """
-
+from aiohttp.test_utils import make_mocked_request
 import pytest
 from halpybot.server.server import server_root
+from tests.fixtures import TestBot
 
 
-# FIXME: This test is not functioning correctly.
-# @pytest.mark.asyncio
-# async def test_root():
-#     """Test the server responds properly to a GET / query"""
-#     mac = await server_root("bacon")
-#     assert mac.status == 200
+@pytest.mark.asyncio
+async def test_root(bot_fx: TestBot):
+    """Test the server responds properly to a GET / query"""
+    request = make_mocked_request("GET", "/")
+    request.app["botclient"] = bot_fx
+    mac = await server_root(request)
+    assert mac.status == 200


### PR DESCRIPTION
Establishes the Case class, which stores case data. Instances of the Case class are stored in the Rescue board. 

Adds a new key of "Type" to the announcer JSON, which is either an Action, a Case, or an Other. This is for future content and automated case creation. 

Reworks the WHOIS command and builds out the beginning of the Seal class, a reference for individual Seals. 

Creates a Platform short global dictionary, to help re-introduce short case abbreviations. 

Reworks the Announcement class to take advantage of `attrs.define`.

Removes the TempRescue class, as it is no longer needed.

Updates a few Board methods to return more specific results or throw exceptions.

Adds a new method to rename a case to the board.

Updates the Permission class to take advantage of `attr.dataclass`

Lays the framework for an on_join case user welcome.

Hands over `attr.dataclass` to `attrs.define` globally.

Closes #303 