### PR TITLE
[Halpy-111] Case Management Commands & Notes

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -30,7 +30,7 @@ irc::sasl::identity="{{SASL_IDENTITY}}"
 api_connector::key="{{API_CONNECTOR_KEY}}"
 api_connector::key_check_constant="{{API_CONNECTOR_CHECK_CONSTANT}}"
 
-channels = '{"channel_list": ["#bot-test"]}'
+channels = '{"channel_list": ["#bot-test", "#cybers"], "rescue_channels": ["#bot-test", "#cybers"]}'
 forced_join = '{"joinable": ["#bot-test", "#cybers"]}'
 
 ###

--- a/data/help/commands.json
+++ b/data/help/commands.json
@@ -96,6 +96,11 @@
       "aliases:": [],
       "arguments": "[Board ID] [New System]",
       "use": "Set the updated client's System."
+    },
+    "status": {
+      "aliases:": [],
+      "arguments": "[Board ID] [New Status]",
+      "use": "Set the updated case status. \nValid options include 'ACTIVE', 'DELAYED', and 'INACTIVE'."
     }
   },
   "Facts": {

--- a/data/help/commands.json
+++ b/data/help/commands.json
@@ -116,6 +116,26 @@
       "aliases:": [],
       "arguments": "[Board ID] [New Case Platform]",
       "use": "Set the updated case platform.\nValid options include 'Odyssey', 'Live', 'Legacy', 'Xbox' and 'PlayStation'."
+    },
+    "notes": {
+      "aliases:": ["addnote", "updatenotes"],
+      "arguments": "[Board ID] [New Case Note]",
+      "use": "Adds a new line to the case notes."
+    },
+    "listnotes": {
+      "aliases:": [],
+      "arguments": "[Board ID]",
+      "use": "List the case notes for the given case."
+    },
+    "delnote": {
+      "aliases:": [],
+      "arguments": "[Board ID] [Note Index]",
+      "use": "List the case notes for the given case."
+    },
+    "editnote": {
+      "aliases:": [],
+      "arguments": "[Board ID] [Note Index] [New Note Content]",
+      "use": "Edit the case notes for the given case and note index."
     }
   },
   "Facts": {

--- a/data/help/commands.json
+++ b/data/help/commands.json
@@ -90,7 +90,12 @@
     "ircn": {
       "aliases:": [],
       "arguments": "[Board ID] [Valid IRC User]",
-      "use": "Set the updated client's IRC Name"
+      "use": "Set the updated client's IRC Name."
+    },
+    "system": {
+      "aliases:": [],
+      "arguments": "[Board ID] [New System]",
+      "use": "Set the updated client's System."
     }
   },
   "Facts": {

--- a/data/help/commands.json
+++ b/data/help/commands.json
@@ -81,6 +81,16 @@
       "aliases:": [],
       "arguments": "[Board ID]",
       "use": "List specific details of a current case."
+    },
+    "rename": {
+      "aliases:": [],
+      "arguments": "[Board ID] [New Client Name]",
+      "use": "Rename the client for the given case."
+    },
+    "ircn": {
+      "aliases:": [],
+      "arguments": "[Board ID] [Valid IRC User]",
+      "use": "Set the updated client's IRC Name"
     }
   },
   "Facts": {

--- a/data/help/commands.json
+++ b/data/help/commands.json
@@ -146,6 +146,11 @@
       "aliases:": [],
       "arguments": "[Board ID] [X Coordinate] [Y Coordinate]",
       "use": "Edit the planetary coordinates for a given KF Case."
+    },
+    "o2time": {
+      "aliases:": [],
+      "arguments": "[Board ID] [O2 Time in NN:NN]",
+      "use": "Change the remaining oxygen timer for a case."
     }
   },
   "Facts": {

--- a/data/help/commands.json
+++ b/data/help/commands.json
@@ -136,6 +136,16 @@
       "aliases:": [],
       "arguments": "[Board ID] [Note Index] [New Note Content]",
       "use": "Edit the case notes for the given case and note index."
+    },
+    "planet": {
+      "aliases:": [],
+      "arguments": "[Board ID] [New Planet]",
+      "use": "Edit the planet for a given KF Case."
+    },
+    "casecoords": {
+      "aliases:": [],
+      "arguments": "[Board ID] [X Coordinate] [Y Coordinate]",
+      "use": "Edit the planetary coordinates for a given KF Case."
     }
   },
   "Facts": {

--- a/data/help/commands.json
+++ b/data/help/commands.json
@@ -111,6 +111,11 @@
       "aliases:": [],
       "arguments": "[Board ID] [New Case Type]",
       "use": "Set the updated case type.\nValid options include 'Seal', 'Black', 'Blue', and 'Fish'."
+    },
+    "platform": {
+      "aliases:": [],
+      "arguments": "[Board ID] [New Case Platform]",
+      "use": "Set the updated case platform.\nValid options include 'Odyssey', 'Live', 'Legacy', 'Xbox' and 'PlayStation'."
     }
   },
   "Facts": {

--- a/data/help/commands.json
+++ b/data/help/commands.json
@@ -100,7 +100,17 @@
     "status": {
       "aliases:": [],
       "arguments": "[Board ID] [New Status]",
-      "use": "Set the updated case status. \nValid options include 'ACTIVE', 'DELAYED', and 'INACTIVE'."
+      "use": "Set the updated case status.\nValid options include 'ACTIVE', 'DELAYED', and 'INACTIVE'."
+    },
+    "hull": {
+      "aliases:": [],
+      "arguments": "[Board ID] [New Hull %]",
+      "use": "Set the updated case hull percentage."
+    },
+    "casetype": {
+      "aliases:": [],
+      "arguments": "[Board ID] [New Case Type]",
+      "use": "Set the updated case type.\nValid options include 'Seal', 'Black', 'Blue', and 'Fish'."
     }
   },
   "Facts": {

--- a/data/help/commands.json
+++ b/data/help/commands.json
@@ -74,7 +74,7 @@
     },
     "listboard": {
       "aliases:": [],
-      "arguments": "",
+      "arguments": "[Case Type or Platform]",
       "use": "Print out the current cases on the Board."
     },
     "listcase": {
@@ -151,6 +151,11 @@
       "aliases:": [],
       "arguments": "[Board ID] [O2 Time in NN:NN]",
       "use": "Change the remaining oxygen timer for a case."
+    },
+    "synth": {
+      "aliases:": [],
+      "arguments": "[Board ID] [Yes/True/No/False]",
+      "use": "Toggle if a CMDR has synths available for a given case."
     }
   },
   "Facts": {

--- a/halpybot/commands/caseutils.py
+++ b/halpybot/commands/caseutils.py
@@ -138,13 +138,13 @@ async def cmd_listboard(ctx: Context, args: List[str]):
 
     message = "Here's the current case board:\n\n"
     for case in filtered_cases:
-        hskf = (
-            "Seal"
-            if case.case_type in (CaseType.SEAL, CaseType.BLUE, CaseType.BLACK)
-            else "Fisher"
-            if case.case_type == CaseType.FISH
-            else "Unknown"
-        )
+        hskf_by_type = {
+            CaseType.SEAL: "Seal",
+            CaseType.BLACK: "Seal",
+            CaseType.BLUE: "Seal",
+            CaseType.FISH: "Fisher",
+        }
+        hskf = hskf_by_type.get(case.case_type, "Unknown")
         long_ago = now(tz="utc").diff(case.updated_time).in_words()
         plt = case.platform.name.replace("_", " ")
         message += (

--- a/halpybot/commands/caseutils.py
+++ b/halpybot/commands/caseutils.py
@@ -113,27 +113,20 @@ async def cmd_listboard(ctx: Context, args: List[str]):
         return await ctx.redirect("The case board is empty!")
     # Process Args (If Exist)
     list_filter = args[0].casefold() if args else None
-    if not list_filter:
-        filtered_cases = caseboard.values()
-    else:
-        filtered_cases = (
-            case
-            for case in caseboard.values()
-            if list_filter
-            in (
-                case.platform.name.casefold().replace("_horizons", ""),
-                case.case_type.name.casefold(),
-            )
-        )
-
+    hskf_by_type = {
+        CaseType.SEAL: "Seal",
+        CaseType.BLACK: "Seal",
+        CaseType.BLUE: "Seal",
+        CaseType.FISH: "Fisher",
+    }
+    count = 0
     message = "Here's the current case board:\n\n"
-    for case in filtered_cases:
-        hskf_by_type = {
-            CaseType.SEAL: "Seal",
-            CaseType.BLACK: "Seal",
-            CaseType.BLUE: "Seal",
-            CaseType.FISH: "Fisher",
-        }
+    for case in caseboard.values():
+        if list_filter and list_filter not in (
+            case.platform.name.casefold().replace("_horizons", ""),
+            case.case_type.name.casefold(),
+        ):
+            continue
         hskf = hskf_by_type.get(case.case_type, "Unknown")
         long_ago = now(tz="utc").diff(case.updated_time).in_words()
         plt = case.platform.name.replace("_", " ")
@@ -141,10 +134,13 @@ async def cmd_listboard(ctx: Context, args: List[str]):
             f"Case {case.board_id}: Client: {case.client_name}, Platform: {plt}, "
             f"Type: {hskf}, Status: {case.status.name}, Updated: {long_ago} ago.\n"
         )
+        count += 1
 
     message += f"\n{len(caseboard)} Cases on the Board."
     if list_filter:
-        message += f" Showing {len(list(filtered_cases))} that match(es) the filter {list_filter!r}."
+        message += f" Showing {count} that match(es) the filter {list_filter!r}."
+    if count == 0:
+        message = f"No cases on the board that match the filter {list_filter!r}."
     return await ctx.redirect(message)
 
 

--- a/halpybot/commands/caseutils.py
+++ b/halpybot/commands/caseutils.py
@@ -619,8 +619,7 @@ async def cmd_delnote(ctx: Context, args: List[str], case: Case):
     except (ValueError, IndexError):
         return await ctx.reply("Invalid Note Index provided!")
     await ctx.reply(f"Removing line {target_line!r}")
-    notes: List[str] = case.case_notes
-    del notes[del_index]
+    del case.case_notes[del_index]
     await ctx.bot.board.mod_case_notes(case_id=case.board_id, new_notes=notes)
     return await ctx.reply(f"Notes for case {case.board_id} updated.")
 
@@ -645,6 +644,8 @@ async def cmd_editnote(ctx: Context, args: List[str], case: Case):
     except (ValueError, IndexError):
         return await ctx.reply("Invalid Note Index provided!")
     await ctx.reply(f"Editing line {target_line!r} to the provided text.")
-    case.case_notes[note_index] = f"{' '.join(args[2:])} - {ctx.sender} ({now(tz='UTC')})"
+    case.case_notes[
+        note_index
+    ] = f"{' '.join(args[2:])} - {ctx.sender} ({now(tz='UTC')})"
     await ctx.bot.board.mod_case_notes(case_id=case.board_id, new_notes=notes)
     return await ctx.reply(f"Notes for case {case.board_id} updated.")

--- a/halpybot/commands/caseutils.py
+++ b/halpybot/commands/caseutils.py
@@ -112,9 +112,7 @@ async def cmd_listboard(ctx: Context, args: List[str]):
     if not caseboard:
         return await ctx.redirect("The case board is empty!")
     # Process Args (If Exist)
-    list_filter = None
-    if args:
-        list_filter = args[0].casefold()
+    list_filter = args[0].casefold() if args else None
     if not list_filter:
         filtered_cases = caseboard.values()
     else:

--- a/halpybot/commands/caseutils.py
+++ b/halpybot/commands/caseutils.py
@@ -10,6 +10,7 @@ See license.md
 import functools
 import re
 from typing import List
+from attrs.converters import to_bool
 from pendulum import now
 from halpybot import config
 from ..packages.command import Commands, get_help_text
@@ -307,15 +308,19 @@ async def cmd_changetype(ctx: Context, args: List[str], case: Case):
     FISH = 4
     """
     potential_type = args[1].casefold()
-    if potential_type == "seal":
-        new_type = CaseType.SEAL
-    elif potential_type in {"kf", "fisher", "fish", "kingfish", "kingfisher"}:
-        new_type = CaseType.FISH
-    elif potential_type == "blue":
-        new_type = CaseType.BLUE
-    elif potential_type in ("black", "cb"):
-        new_type = CaseType.BLACK
-    else:
+    type_lookup = {
+        "seal": CaseType.SEAL,
+        "kf": CaseType.FISH,
+        "fisher": CaseType.FISH,
+        "fish": CaseType.FISH,
+        "kingfish": CaseType.FISH,
+        "kingfisher": CaseType.FISH,
+        "blue": CaseType.BLUE,
+        "black": CaseType.BLACK,
+        "cb": CaseType.BLACK,
+    }
+    new_type = type_lookup.get(potential_type)
+    if new_type is None:
         return await ctx.reply("Invalid New Case Type Given.")
     update = await update_single_elem_case_prep(
         ctx=ctx,
@@ -347,18 +352,25 @@ async def cmd_platform(ctx: Context, args: List[str], case: Case):
     LIVE_HORIZONS = 5
     UNKNOWN = 6
     """
+    platform_lookup = {
+        "odyssey": Platform.ODYSSEY,
+        "ody": Platform.ODYSSEY,
+        "pc": Platform.ODYSSEY,
+        "pc-o": Platform.ODYSSEY,
+        "xbx": Platform.XBOX,
+        "xb": Platform.XBOX,
+        "xbox": Platform.XBOX,
+        "ps4": Platform.PLAYSTATION,
+        "ps": Platform.PLAYSTATION,
+        "playstation": Platform.PLAYSTATION,
+        "live": Platform.LIVE_HORIZONS,
+        "horizons-live": Platform.LIVE_HORIZONS,
+        "legacy": Platform.LEGACY_HORIZONS,
+        "legacy-horizons": Platform.LEGACY_HORIZONS,
+    }
     potential_plt = args[1].casefold()
-    if potential_plt in ("odyssey", "ody", "pc", "pc-o"):
-        new_plt = Platform.ODYSSEY
-    elif potential_plt in ("xbx", "xb", "xbox"):
-        new_plt = Platform.XBOX
-    elif potential_plt in ("ps4", "ps", "playstation"):
-        new_plt = Platform.PLAYSTATION
-    elif potential_plt in ("live", "horizons-live"):
-        new_plt = Platform.LIVE_HORIZONS
-    elif potential_plt in ("legacy", "legacy-horizons"):
-        new_plt = Platform.LEGACY_HORIZONS
-    else:
+    new_plt = platform_lookup.get(potential_plt)
+    if new_plt is None:
         return await ctx.reply("Invalid New Case Type Given.")
     update = await update_single_elem_case_prep(
         ctx=ctx,
@@ -461,20 +473,18 @@ async def cmd_synth(ctx: Context, args: List[str], case: Case):
     Usage: !synth [board ID] [Yes/True/No/False]
     Aliases: n/a
     """
-    if args[1].casefold() in ("yes", "true"):
-        new_synth = True
-    elif args[1].casefold() in ("no", "false"):
-        new_synth = False
-    else:
+    try:
+        new_stat = to_bool(args[1].casefold())
+    except ValueError:
         return await ctx.reply("Invalid synth ability given.")
-    if new_synth == case.can_synth:
-        return await ctx.reply(f"Synth available already set to {new_synth}")
+    if new_stat == case.can_synth:
+        return await ctx.reply(f"Synth available already set to {new_stat}")
     update = await update_single_elem_case_prep(
         ctx=ctx,
         case=case,
         action="Synth Status",
         new_key="can_synth",
-        new_item=new_synth,
+        new_item=new_stat,
     )
     if update:
         return await ctx.reply(update)
@@ -492,12 +502,15 @@ async def cmd_canopy(ctx: Context, args: List[str], case: Case):
     Aliases: n/a
     """
     # Gather Args
-    if args[1].casefold() in ("yes", "true", "broken"):
-        canopy_broken = True
-    elif args[1].casefold() in ("no", "false", "intact"):
-        canopy_broken = False
-    else:
-        return await ctx.reply("Invalid Canopy Status given.")
+    try:
+        canopy_broken = to_bool(args[1].casefold())
+    except ValueError:
+        if args[1].casefold() == "broken":
+            canopy_broken = True
+        elif args[1].casefold() == "intact":
+            canopy_broken = False
+        else:
+            return await ctx.reply("Invalid Canopy Status given.")
     if case.case_type not in (CaseType.BLACK, CaseType.BLUE):
         return await ctx.reply("Canopy Status Can't Be Changed for Non-CB Cases!")
     update = await update_single_elem_case_prep(

--- a/halpybot/commands/caseutils.py
+++ b/halpybot/commands/caseutils.py
@@ -325,7 +325,7 @@ async def cmd_changetype(ctx: Context, args: List[str], case: Case):
     potential_type = args[1].casefold()
     if potential_type == "seal":
         new_type = CaseType.SEAL
-    elif potential_type in ("kf", "fisher", "fish", "kingfish", "kingfisher"):
+    elif potential_type in {"kf", "fisher", "fish", "kingfish", "kingfisher"}:
         new_type = CaseType.FISH
     elif potential_type == "blue":
         new_type = CaseType.BLUE

--- a/halpybot/commands/caseutils.py
+++ b/halpybot/commands/caseutils.py
@@ -144,7 +144,9 @@ async def cmd_ircn(ctx: Context, args: List[str]):
         return await ctx.reply(f"No case found for {args[0]!r}.")
     new_details = {"irc_nick": args[1]}
     action = "IRC Name"
-    await update_single_elem_case_prep(ctx, case, action, new_details)
+    update = await update_single_elem_case_prep(ctx, case, action, new_details)
+    if update:
+        return await ctx.reply(update)
 
 
 @Commands.command("system")
@@ -168,7 +170,9 @@ async def cmd_system(ctx: Context, args: List[str]):
     newsys = await sys_cleaner(newsys)
     new_details = {"system": newsys}
     action = "Client System"
-    await update_single_elem_case_prep(ctx, case, action, new_details)
+    update = await update_single_elem_case_prep(ctx, case, action, new_details)
+    if update:
+        return await ctx.reply(update)
 
 
 @Commands.command("status")
@@ -195,7 +199,11 @@ async def cmd_status(ctx: Context, args: List[str]):
         return await ctx.reply("Invalid case status provided.")
     new_details = {"status": status}
     action = "Case Status"
-    await update_single_elem_case_prep(ctx, case, action, new_details, enum=True)
+    update = await update_single_elem_case_prep(
+        ctx, case, action, new_details, enum=True
+    )
+    if update:
+        return await ctx.reply(update)
 
 
 @Commands.command("hull")
@@ -222,7 +230,9 @@ async def cmd_hull(ctx: Context, args: List[str]):
         return await ctx.reply(f"{args[1]!r} isn't a valid hull percentage")
     new_details = {"hull_percent": percent}
     action = "Hull Percentage"
-    await update_single_elem_case_prep(ctx, case, action, new_details)
+    update = await update_single_elem_case_prep(ctx, case, action, new_details)
+    if update:
+        return await ctx.reply(update)
 
 
 @Commands.command("changetype")
@@ -259,4 +269,8 @@ async def cmd_changetype(ctx: Context, args: List[str]):
         return await ctx.reply("Invalid New Case Type Given.")
     new_details = {"case_type": new_type}
     action = "Case Type"
-    await update_single_elem_case_prep(ctx, case, action, new_details, enum=True)
+    update = await update_single_elem_case_prep(
+        ctx, case, action, new_details, enum=True
+    )
+    if update:
+        return await ctx.reply(update)

--- a/halpybot/commands/caseutils.py
+++ b/halpybot/commands/caseutils.py
@@ -27,6 +27,7 @@ from ..packages.models import (
     CaseType,
     Platform,
     KFCoords,
+    KFType,
 )
 from ..packages.checks import Require, Drilled
 from ..packages.case import get_case, update_single_elem_case_prep
@@ -315,7 +316,7 @@ async def cmd_changetype(ctx: Context, args: List[str]):
     """
     Change the case type between Seal, KF, Black, or Blue.
 
-    Usage: !hull [board ID] [new type]
+    Usage: !changetype [board ID] [new type]
     Aliases: n/a
 
     SEAL = 1
@@ -523,6 +524,46 @@ async def cmd_synth(ctx: Context, args: List[str]):
         action="Synth Status",
         new_key="can_synth",
         new_item=new_synth,
+    )
+    if update:
+        return await ctx.reply(update)
+
+
+@Commands.command("kftype")
+@Require.permission(Drilled)
+@Require.channel()
+async def cmd_changetype(ctx: Context, args: List[str]):
+    """
+    Change the case type between KF subtypes.
+
+    Usage: !kftype [board ID] [new type]
+    Aliases: n/a
+
+    LIFT = 0
+    GOLF = 1
+    PUCK = 2
+    PICK = 3
+    """
+    if len(args) < 2:
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "kftype"))
+    try:
+        case: Case = await get_case(ctx, args[0])
+    except KeyError:
+        return await ctx.reply(f"No case found for {args[0]!r}.")
+    if case.case_type != CaseType.FISH:
+        return await ctx.reply("KFType can't be changed for non-Fisher case")
+    potential_type = args[1].casefold()
+    try:
+        new_type = getattr(KFType, potential_type.upper())
+    except AttributeError:
+        return await ctx.reply("Invalid New KF Subtype Given.")
+    update = await update_single_elem_case_prep(
+        ctx=ctx,
+        case=case,
+        action="Kingfisher Type",
+        new_key="kftype",
+        new_item=new_type,
+        enum=True,
     )
     if update:
         return await ctx.reply(update)

--- a/halpybot/commands/caseutils.py
+++ b/halpybot/commands/caseutils.py
@@ -202,7 +202,7 @@ async def cmd_status(ctx: Context, args: List[str]):
     """
     Change the activity status of a case
 
-    Usage: !active [board ID] [new status]
+    Usage: !status [board ID] [new status]
     Aliases: n/a
     """
     if len(args) < 2:

--- a/halpybot/commands/caseutils.py
+++ b/halpybot/commands/caseutils.py
@@ -529,10 +529,48 @@ async def cmd_synth(ctx: Context, args: List[str]):
         return await ctx.reply(update)
 
 
+@Commands.command("canopy")
+@Require.permission(Drilled)
+@Require.channel()
+async def cmd_canopy(ctx: Context, args: List[str]):
+    """
+    Toggle if the canopy is broken for a given case.
+
+    Usage: !canopy [board ID] [Yes/True/No/False]
+    Aliases: n/a
+    """
+    # Gather Case
+    if len(args) < 2:
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "synth"))
+    try:
+        case: Case = await get_case(ctx, args[0])
+    except KeyError:
+        return await ctx.reply(f"No case found for {args[0]!r}.")
+
+    # Gather Args
+    if args[1].casefold() in ("yes", "true", "broken"):
+        canopy_broken = True
+    elif args[1].casefold() in ("no", "false", "intact"):
+        canopy_broken = False
+    else:
+        return await ctx.reply("Invalid Canopy Status given.")
+    if case.case_type not in (CaseType.BLACK, CaseType.BLUE):
+        return await ctx.reply("Canopy Status Can't Be Changed for Non-CB Cases!")
+    update = await update_single_elem_case_prep(
+        ctx=ctx,
+        case=case,
+        action="Canopy Status",
+        new_key="canopy_broken",
+        new_item=canopy_broken,
+    )
+    if update:
+        return await ctx.reply(update)
+
+
 @Commands.command("kftype")
 @Require.permission(Drilled)
 @Require.channel()
-async def cmd_changetype(ctx: Context, args: List[str]):
+async def cmd_changekftype(ctx: Context, args: List[str]):
     """
     Change the case type between KF subtypes.
 

--- a/halpybot/commands/caseutils.py
+++ b/halpybot/commands/caseutils.py
@@ -20,6 +20,7 @@ from ..packages.models import (
     Status,
     CaseType,
     Platform,
+    KFCoords,
 )
 from ..packages.checks import Require, Drilled
 from ..packages.case import get_case, update_single_elem_case_prep
@@ -342,6 +343,67 @@ async def cmd_platform(ctx: Context, args: List[str]):
         new_key="platform",
         new_item=new_plt,
         enum=True,
+    )
+    if update:
+        return await ctx.reply(update)
+
+
+@Commands.command("planet")
+@Require.permission(Drilled)
+@Require.channel()
+async def cmd_planet(ctx: Context, args: List[str]):
+    """
+    Change the planet of an active KF case
+
+    Usage: !planet [board ID] [new system]
+    Aliases: n/a
+    """
+    if len(args) < 2:
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "planet"))
+    try:
+        case: Case = await get_case(ctx, args[0])
+    except KeyError:
+        return await ctx.reply(f"No case found for {args[0]!r}.")
+    if case.case_type != CaseType.FISH:
+        return await ctx.reply("Planet can't be changed for non-Fisher case")
+    newplan = await sys_cleaner(" ".join(args[1:]))
+    update = await update_single_elem_case_prep(
+        ctx=ctx, case=case, action="Client Planet", new_key="planet", new_item=newplan
+    )
+    if update:
+        return await ctx.reply(update)
+
+
+@Commands.command("casecoords")
+@Require.permission(Drilled)
+@Require.channel()
+async def cmd_planet(ctx: Context, args: List[str]):
+    """
+    Change the coords of an active KF case
+
+    Usage: !casecoords [board ID] [X Coordinate Float] [Y Coordinate Float]
+    Aliases: n/a
+    """
+    if len(args) < 2:
+        return await ctx.reply(get_help_text(ctx.bot.commandsfile, "casecoords"))
+    try:
+        case: Case = await get_case(ctx, args[0])
+    except KeyError:
+        return await ctx.reply(f"No case found for {args[0]!r}.")
+    if case.case_type != CaseType.FISH:
+        return await ctx.reply("Coordinates can't be changed for non-Fisher case")
+    try:
+        xcoord = float(args[1].strip())
+        ycoord = float(args[2].strip())
+    except ValueError:
+        raise ValueError("KF Coordinates Improperly Formatted")
+    newcoords = KFCoords(xcoord, ycoord)
+    update = await update_single_elem_case_prep(
+        ctx=ctx,
+        case=case,
+        action="Client Coordinates",
+        new_key="pcoords",
+        new_item=newcoords,
     )
     if update:
         return await ctx.reply(update)

--- a/halpybot/commands/caseutils.py
+++ b/halpybot/commands/caseutils.py
@@ -112,29 +112,21 @@ async def cmd_listboard(ctx: Context, args: List[str]):
     if not caseboard:
         return await ctx.redirect("The case board is empty!")
     # Process Args (If Exist)
+    list_filter = None
     if args:
-        platforms = [
-            member.name.casefold().replace("_horizons", "") for member in Platform
-        ]
-        casetypes = [member.name.casefold() for member in CaseType]
         list_filter = args[0].casefold()
-        if list_filter not in casetypes and list_filter not in platforms:
-            list_filter = None
+    if not list_filter:
+        filtered_cases = caseboard.values()
     else:
-        list_filter = None
-
-    filtered_cases = [
-        case
-        for case in caseboard.values()
-        if (not list_filter)
-        or (
-            list_filter
+        filtered_cases = (
+            case
+            for case in caseboard.values()
+            if list_filter
             in (
                 case.platform.name.casefold().replace("_horizons", ""),
                 case.case_type.name.casefold(),
             )
         )
-    ]
 
     message = "Here's the current case board:\n\n"
     for case in filtered_cases:
@@ -154,9 +146,7 @@ async def cmd_listboard(ctx: Context, args: List[str]):
 
     message += f"\n{len(caseboard)} Cases on the Board."
     if list_filter:
-        message += (
-            f" Showing {len(filtered_cases)} that match(es) the filter {list_filter!r}."
-        )
+        message += f" Showing {len(list(filtered_cases))} that match(es) the filter {list_filter!r}."
     return await ctx.redirect(message)
 
 

--- a/halpybot/commands/caseutils.py
+++ b/halpybot/commands/caseutils.py
@@ -645,7 +645,6 @@ async def cmd_editnote(ctx: Context, args: List[str], case: Case):
     except (ValueError, IndexError):
         return await ctx.reply("Invalid Note Index provided!")
     await ctx.reply(f"Editing line {target_line!r} to the provided text.")
-    notes: List[str] = case.case_notes
-    notes[note_index] = f"{' '.join(args[2:])} - {ctx.sender} ({now(tz='UTC')})"
+    case.case_notes[note_index] = f"{' '.join(args[2:])} - {ctx.sender} ({now(tz='UTC')})"
     await ctx.bot.board.mod_case_notes(case_id=case.board_id, new_notes=notes)
     return await ctx.reply(f"Notes for case {case.board_id} updated.")

--- a/halpybot/commands/caseutils.py
+++ b/halpybot/commands/caseutils.py
@@ -291,7 +291,7 @@ async def cmd_hull(ctx: Context, args: List[str], case: Case):
         return await ctx.reply("Hull can't be changed for non-Seal case")
     try:
         percent = int(args[1])
-        if not 0 <= percent <= 100:
+        if percent not in range(100):
             raise ValueError  # Mock a Value Error for invalid Hull Percentage
     except ValueError:
         return await ctx.reply(f"{args[1]!r} isn't a valid hull percentage")
@@ -620,7 +620,7 @@ async def cmd_delnote(ctx: Context, args: List[str], case: Case):
         return await ctx.reply("Invalid Note Index provided!")
     await ctx.reply(f"Removing line {target_line!r}")
     del case.case_notes[del_index]
-    await ctx.bot.board.mod_case_notes(case_id=case.board_id, new_notes=notes)
+    await ctx.bot.board.mod_case_notes(case_id=case.board_id, new_notes=case.case_notes)
     return await ctx.reply(f"Notes for case {case.board_id} updated.")
 
 
@@ -647,5 +647,5 @@ async def cmd_editnote(ctx: Context, args: List[str], case: Case):
     case.case_notes[
         note_index
     ] = f"{' '.join(args[2:])} - {ctx.sender} ({now(tz='UTC')})"
-    await ctx.bot.board.mod_case_notes(case_id=case.board_id, new_notes=notes)
+    await ctx.bot.board.mod_case_notes(case_id=case.board_id, new_notes=case.case_notes)
     return await ctx.reply(f"Notes for case {case.board_id} updated.")

--- a/halpybot/commands/debug.py
+++ b/halpybot/commands/debug.py
@@ -10,9 +10,8 @@ Licensed under the GNU General Public License
 See license.md
 """
 from typing import List
-from attrs import evolve
 from ..packages.command import Commands
-from ..packages.models import Context, Platform, Case
+from ..packages.models import Context, Case
 
 
 @Commands.command("nextid")
@@ -20,31 +19,18 @@ async def cmd_nextid(ctx: Context, args: List[str]):
     await ctx.reply(f"ID: {ctx.bot.board.open_rescue_id}")
 
 
-@Commands.command("loadboard")
-async def cmd_loadboard(ctx: Context, args: List[str]):
-    await ctx.bot.board.debug_load_board
-    return await ctx.reply("Debug Data Loaded!")
-
-
-@Commands.command("clearboard")
+@Commands.command("delcase")
 async def cmd_clearboard(ctx: Context, args: List[str]):
-    await ctx.bot.board.debug_clear_board
-    return await ctx.reply("Board Cleared!")
-
-
-@Commands.command("fullboard")
-async def cmd_fullboard(ctx: Context, args: List[str]):
-    await ctx.bot.board.debug_full_board
-    return await ctx.reply("Debug Full Data Loaded!")
-
-
-@Commands.command("newcase")
-async def cmd_newcase(ctx: Context, args: List[str]):
-    cmdr = args[0]
-    plt = Platform(int(args[1]))
-    sys = args[2]
-    case = await ctx.bot.board.add_case(client=cmdr, platform=plt, system=sys)
-    return await ctx.reply(f"New case started: Board ID {case.board_id}")
+    try:
+        caseref = int(args[0])
+    except ValueError:
+        caseref = args[0]
+    try:
+        case: Case = ctx.bot.board.return_rescue(caseref)
+    except KeyError:
+        return await ctx.reply("[DEBUG] No case found.")
+    await ctx.bot.board.del_case(case)
+    return await ctx.reply("Case Cleared!")
 
 
 @Commands.command("debugwelcome")

--- a/halpybot/commands/settings.py
+++ b/halpybot/commands/settings.py
@@ -10,6 +10,7 @@ See license.md
 
 from typing import List
 from loguru import logger
+from attrs.converters import to_bool
 import pydle
 from halpybot import config
 from ..packages.checks import Require, Cyberseal
@@ -80,20 +81,22 @@ async def cmd_offline(ctx: Context, args: List[str]):
             f"{get_help_text(ctx.bot.commandsfile, 'settings offline')}\nCurrent "
             f"offline setting: {config.offline_mode.enabled}"
         )
-    if not args[0].casefold() in ("true", "false"):
+    try:
+        new_stat = to_bool(args[0].casefold())
+    except ValueError:
         return await ctx.reply("Error! Invalid parameters given. Status not changed.")
-
-    to_offline = args[0].casefold() == "true"
-
+    if new_stat == config.offline_mode.enabled:
+        return await ctx.reply(
+            f"Offline mode already set to {new_stat}. Status not changed."
+        )
     logger.info(
         "OFFLINE MODE CHANGE from {mode} to {new} by {sender}",
         mode=config.offline_mode.enabled,
-        new=to_offline,
+        new=new_stat,
         sender=ctx.sender,
     )
-    config.offline_mode.enabled = to_offline
-    # Write changes to config file
-    await ctx.reply(f"Warning! Offline Mode Status Changed to {to_offline}")
+    config.offline_mode.enabled = new_stat
+    await ctx.reply(f"Warning! Offline Mode Status Changed to {new_stat}")
 
 
 @Commands.command("joinchannel")

--- a/halpybot/halpyconfig.py
+++ b/halpybot/halpyconfig.py
@@ -80,6 +80,7 @@ class Channels(BaseModel):
     """Channel List Config"""
 
     channel_list: List[str]
+    rescue_channels: List[str]
 
 
 class Database(BaseModel):

--- a/halpybot/packages/announcer/__init__.py
+++ b/halpybot/packages/announcer/__init__.py
@@ -15,6 +15,7 @@ from .announcer import (
     get_edsm_data,
     AlreadyExistsError,
     AnnouncerArgs,
+    KFCoordsError,
 )
 from .dc_webhook import send_webhook, DiscordWebhookError, WebhookSendError
 
@@ -25,6 +26,7 @@ __all__ = [
     "get_edsm_data",
     "AlreadyExistsError",
     "AnnouncerArgs",
+    "KFCoordsError",
     "send_webhook",
     "DiscordWebhookError",
     "WebhookSendError",

--- a/halpybot/packages/announcer/announcer.py
+++ b/halpybot/packages/announcer/announcer.py
@@ -272,4 +272,8 @@ class Announcement:
                 announcement += await get_edsm_data(args)
             except ValueError:
                 announcement += "\nAttention Dispatch, please confirm clients system before proceeding."
+        if args.get("Board_ID"):
+            case = client.board.return_rescue(args["Board_ID"])
+            if case.irc_nick != case.client_name:
+                announcement += f"\nExpected IRC User: {case.irc_nick}"
         return announcement

--- a/halpybot/packages/announcer/announcer.py
+++ b/halpybot/packages/announcer/announcer.py
@@ -131,6 +131,12 @@ class AlreadyExistsError(AnnouncementError):
     """
 
 
+class KFCoordsError(AnnouncementError):
+    """
+    Given Kingfisher Coordinates were not Floatable
+    """
+
+
 class Announcer:
     """The Announcer - Send Messages to All Points"""
 
@@ -185,6 +191,9 @@ class Announcer:
         except AlreadyExistsError as aee:
             logger.exception("Case Already Exists Matching")
             raise AlreadyExistsError from aee
+        except KFCoordsError:
+            logger.exception("KFCoords were invalid!")
+            raise KFCoordsError
         except Exception as announcement_exception:
             logger.exception("An announcement exception occurred!")
             raise AnnouncementError(Exception) from announcement_exception
@@ -263,7 +272,11 @@ class Announcement:
             try:
                 args["Board_ID"] = await create_case(args, codemap, client)
             except ValueError as val_err:
-                raise AlreadyExistsError("Case Already Exists") from val_err
+                if str(val_err) == "KF Coordinates Improperly Formatted":
+                    raise KFCoordsError from val_err
+                else:
+                    raise AlreadyExistsError("Case Already Exists") from val_err
+
         # Finally, format and return
         formatted_content = "".join(self.content)
         announcement = formatted_content.format(**args)

--- a/halpybot/packages/board/board.py
+++ b/halpybot/packages/board/board.py
@@ -210,11 +210,13 @@ class Board:
         """
         Modify an existing case
         """
+        case = self.return_rescue(case_id)
         curr_time = now(tz="UTC")
-        current_case_notes = self.return_rescue(case_id).case_notes
+        current_case_notes = case.case_notes
+
         if action:
-            for item in kwargs.values():
-                notes = f"{action} set to {item} by {sender} at {curr_time.to_time_string()}"
+            for key, item in kwargs.items():
+                notes = f"{action} set to {item} from {getattr(case, key)} by {sender} at {curr_time.to_time_string()}"
                 current_case_notes.append(notes)
         new_case = evolve(
             self._cases_by_id[case_id],

--- a/halpybot/packages/board/board.py
+++ b/halpybot/packages/board/board.py
@@ -216,6 +216,8 @@ class Board:
 
         if action:
             for key, item in kwargs.items():
+                if getattr(case, key) == item:
+                    raise ValueError(f"{action} is already set to {item}.")
                 notes = f"{action} set to {item} from {getattr(case, key)} by {sender} at {curr_time.to_time_string()}"
                 current_case_notes.append(notes)
         new_case = evolve(

--- a/halpybot/packages/board/board.py
+++ b/halpybot/packages/board/board.py
@@ -129,10 +129,8 @@ class Board:
                     raise ValueError(f"{action} is already set to {item}.")
                 # Translate Enums into Human-Notes
                 if isinstance(item, enum.Enum):
-                    item = item.name
-                    oldkey = getattr(case, key).name
-                    item = item.replace("_", " ")
-                    oldkey = oldkey.replace("_", " ")
+                    item = item.name.replace("_", " ")
+                    oldkey = getattr(case, key).name.replace("_", " ")
                 notes = f"{action} set to {item} from {oldkey} by {sender} at {curr_time.to_time_string()}"
                 current_case_notes.append(notes)
 

--- a/halpybot/packages/board/board.py
+++ b/halpybot/packages/board/board.py
@@ -116,20 +116,27 @@ class Board:
         """
         Modify an existing case
         """
-        case = self.return_rescue(case_id)
+        # Gather the Case Information
+        case: Case = self.return_rescue(case_id)
         curr_time = now(tz="UTC")
         current_case_notes = case.case_notes
 
+        # Prep the new notes
         if action:
             for key, item in kwargs.items():
                 oldkey = getattr(case, key)
                 if getattr(case, key) == item:
                     raise ValueError(f"{action} is already set to {item}.")
+                # Translate Enums into Human-Notes
                 if isinstance(item, enum.Enum):
                     item = item.name
                     oldkey = getattr(case, key).name
+                    item = item.replace("_", " ")
+                    oldkey = oldkey.replace("_", " ")
                 notes = f"{action} set to {item} from {oldkey} by {sender} at {curr_time.to_time_string()}"
                 current_case_notes.append(notes)
+
+        # Update the Case
         new_case = evolve(
             self._cases_by_id[case_id],
             updated_time=curr_time,

--- a/halpybot/packages/board/board.py
+++ b/halpybot/packages/board/board.py
@@ -205,7 +205,7 @@ class Board:
 
     @functools.wraps(evolve)
     async def mod_case(
-        self, case_id: int, action: str = None, append: str = None, sender: str = None, **kwargs
+        self, case_id: int, action: str = None, sender: str = None, **kwargs
     ):
         """
         Modify an existing case
@@ -215,10 +215,6 @@ class Board:
         if action:
             for item in kwargs.values():
                 notes = f"{action} set to {item} by {sender} at {curr_time.to_time_string()}"
-                current_case_notes.append(notes)
-        if append:
-            for item in kwargs.values():
-                notes = f"{item} added to {append} by {sender} at {curr_time.to_time_string()}"
                 current_case_notes.append(notes)
         new_case = evolve(
             self._cases_by_id[case_id],

--- a/halpybot/packages/board/board.py
+++ b/halpybot/packages/board/board.py
@@ -218,7 +218,7 @@ class Board:
                 current_case_notes.append(notes)
         if append:
             for item in kwargs.values():
-                notes = f"{action} added to {item} by {sender} at {curr_time.to_time_string()}"
+                notes = f"{item} added to {append} by {sender} at {curr_time.to_time_string()}"
                 current_case_notes.append(notes)
         new_case = evolve(
             self._cases_by_id[case_id],

--- a/halpybot/packages/board/board.py
+++ b/halpybot/packages/board/board.py
@@ -19,6 +19,8 @@ Licensed under the GNU General Public License
 See license.md
 """
 from __future__ import annotations
+
+import enum
 import typing
 import functools
 import itertools
@@ -120,11 +122,13 @@ class Board:
 
         if action:
             for key, item in kwargs.items():
+                oldkey = getattr(case, key)
                 if getattr(case, key) == item:
                     raise ValueError(f"{action} is already set to {item}.")
-                if type(item, tuple):
+                if isinstance(item, enum.Enum):
                     item = item.name
-                notes = f"{action} set to {item} from {getattr(case, key)} by {sender} at {curr_time.to_time_string()}"
+                    oldkey = getattr(case, key).name
+                notes = f"{action} set to {item} from {oldkey} by {sender} at {curr_time.to_time_string()}"
                 current_case_notes.append(notes)
         new_case = evolve(
             self._cases_by_id[case_id],

--- a/halpybot/packages/board/board.py
+++ b/halpybot/packages/board/board.py
@@ -143,6 +143,19 @@ class Board:
         )
         self._cases_by_id[case_id] = new_case
 
+    @functools.wraps(evolve)
+    async def mod_case_notes(self, case_id: int, new_notes: typing.List[str]):
+        """
+        Replace the notes of an existing rescue
+        """
+        # Update the Case
+        new_case = evolve(
+            self._cases_by_id[case_id],
+            updated_time=now(tz="UTC"),
+            case_notes=new_notes,
+        )
+        self._cases_by_id[case_id] = new_case
+
     async def del_case(self, case: Case):
         """Delete a Case from the Board"""
         if not isinstance(case, Case):

--- a/halpybot/packages/board/board.py
+++ b/halpybot/packages/board/board.py
@@ -238,7 +238,7 @@ class Board:
             del self._cases_by_id[board_id]
             del self._case_alias_name[client.casefold()]
 
-    async def rename_case(self, new_name: str, case: Case, sender):
+    async def rename_case(self, new_name: str, case: Case, sender: str):
         """Rename an actively referenced case"""
         # Make Sure we have a Case
         if not isinstance(case, Case):

--- a/halpybot/packages/case/__init__.py
+++ b/halpybot/packages/case/__init__.py
@@ -8,6 +8,6 @@ Licensed under the GNU General Public License
 See license.md
 """
 
-from .caseutils import create_case
+from .caseutils import create_case, get_case, update_single_elem_case_prep
 
-__all__ = ["create_case"]
+__all__ = ["create_case", "get_case", "update_single_elem_case_prep"]

--- a/halpybot/packages/case/caseutils.py
+++ b/halpybot/packages/case/caseutils.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import re
 from enum import Enum
 from typing import TYPE_CHECKING, Union, Optional
-from ..models import Case, Platform, CaseType, Context
+from ..models import Case, Platform, CaseType, Context, KFCoords
 from ... import config
 
 if TYPE_CHECKING:
@@ -70,11 +70,17 @@ async def create_case(args: AnnouncerArgs, codemap: Platform, client: HalpyBOT) 
             }
         )
     if case_type == CaseType.FISH:  # kf
+        coords = args["Coords"].split(",")
+        try:
+            xcoord = float(coords[0].strip())
+            ycoord = float(coords[1].strip())
+        except ValueError:
+            raise ValueError("KF Coordinates Improperly Formatted")
         evolve_args.update(
             {
                 "case_type": case_type,
                 "planet": args["Planet"],
-                "pcoords": args["Coords"],
+                "pcoords": KFCoords(xcoord, ycoord),
                 "kftype": args["KFType"],
             }
         )

--- a/halpybot/packages/case/caseutils.py
+++ b/halpybot/packages/case/caseutils.py
@@ -9,8 +9,9 @@ See license.md
 """
 from __future__ import annotations
 import re
-from typing import TYPE_CHECKING
-from ..models import Case, Platform
+from typing import TYPE_CHECKING, Union
+from ..models import Case, Platform, CaseType, Context
+from ... import config
 
 if TYPE_CHECKING:
     from ..ircclient import HalpyBOT
@@ -19,9 +20,20 @@ if TYPE_CHECKING:
 
 async def create_case(args: AnnouncerArgs, codemap: Platform, client: HalpyBOT) -> int:
     """Create a Case on the board from a rescue announcement"""
+    # Determine Type of Case
+    if "CanSynth" in args:  # CB
+        case_type = CaseType.BLACK
+    elif "Coords" in args:  # KF
+        case_type = CaseType.FISH
+    else:
+        case_type = CaseType.SEAL
+
     # Create the base case
     newcase: Case = await client.board.add_case(
-        client=args["CMDR"], platform=codemap, system=args["System"]
+        client=args["CMDR"],
+        platform=codemap,
+        system=args["System"],
+        case_type=case_type,
     )
     evolve_args = {
         "irc_nick": newcase.client_name,
@@ -46,18 +58,20 @@ async def create_case(args: AnnouncerArgs, codemap: Platform, client: HalpyBOT) 
         )
 
     # What type of case are we dealing with?
-    if "CanSynth" in args:  # CB
+    if case_type == CaseType.BLACK:  # CB
         evolve_args.update(
             {
+                "case_type": case_type,
                 "canopy_broken": True,
                 "can_synth": args["CanSynth"],
                 "o2_timer": args["Oxygen"],
                 "hull_percent": int(args["Hull"]),
             }
         )
-    elif "Coords" in args:  # KF
+    if case_type == CaseType.FISH:  # kf
         evolve_args.update(
             {
+                "case_type": case_type,
                 "planet": args["Planet"],
                 "pcoords": args["Coords"],
                 "kftype": args["KFType"],
@@ -66,9 +80,44 @@ async def create_case(args: AnnouncerArgs, codemap: Platform, client: HalpyBOT) 
     else:  # Must be standard Seal
         evolve_args.update(
             {
+                "case_type": case_type,
                 "hull_percent": int(args["Hull"]),
             }
         )
     # Call the wrapped evolve function with **kwargs
     await client.board.mod_case(newcase.board_id, **evolve_args)
     return newcase.board_id
+
+
+async def get_case(ctx: Context, case_arg: str) -> Case:
+    """Fetch a case from the Board"""
+    try:
+        caseref: Union[str, int] = int(case_arg)
+    except ValueError:
+        caseref = case_arg
+    return ctx.bot.board.return_rescue(caseref)
+
+
+async def update_single_elem_case_prep(
+    ctx: Context, case: Case, action: str, new_details, enum: bool = False
+):
+    """
+    Send the updated case details to the board, and handle errors
+    NOTE: Can only handle a single updated value at a time.
+    """
+    # Get the to-be-updated element
+    first_updated = next(iter((new_details.items())))
+    new_key = first_updated[0]
+    new_item = first_updated[1]
+    try:
+        await ctx.bot.board.mod_case(case.board_id, action, ctx.sender, **new_details)
+    except ValueError:
+        return await ctx.reply(
+            f"{action} is already set to {new_item.name if enum else new_item}."
+        )
+    for channel in config.channels.rescue_channels:
+        await ctx.bot.message(
+            channel,
+            f"{action} for case {case.board_id} set to {new_item.name if enum else new_item!r} "
+            f"from {getattr(case, new_key).name if enum else getattr(case, new_key)!r}",
+        )

--- a/halpybot/packages/case/caseutils.py
+++ b/halpybot/packages/case/caseutils.py
@@ -23,17 +23,28 @@ async def create_case(args: AnnouncerArgs, codemap: Platform, client: HalpyBOT) 
     newcase: Case = await client.board.add_case(
         client=args["CMDR"], platform=codemap, system=args["System"]
     )
-    # Determine if an IRCN is needed by default
-    ircn = re.search("/[^a-zA-Z0-9]/", args["CMDR"])
+    evolve_args = {
+        "irc_nick": newcase.client_name,
+    }
+    # Determine if a different IRCN is needed by default
+    ircn = re.search(r"[^a-zA-Z0-9]", newcase.client_name)
     if ircn:
-        ircn = re.sub("/[^a-zA-Z0-9]/", "", args["CMDR"])
+        ircn = re.sub(r"[^a-zA-Z0-9]", "", newcase.client_name)
         # If IRCN needed
-        evolve_args = {
-            "irc_nick": ircn,
-        }
-    else:
-        # If no IRCN needed, save ClientName as IRCN
-        evolve_args = {"irc_nick": newcase.client_name}
+        evolve_args.update(
+            {
+                "irc_nick": ircn,
+            }
+        )
+    if evolve_args["irc_nick"][0].isdigit():
+        ircn = evolve_args["irc_nick"]
+        ircn = f"CMDR_{ircn}"
+        evolve_args.update(
+            {
+                "irc_nick": ircn,
+            }
+        )
+
     # What type of case are we dealing with?
     if "CanSynth" in args:  # CB
         evolve_args.update(

--- a/halpybot/packages/case/caseutils.py
+++ b/halpybot/packages/case/caseutils.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import re
 from enum import Enum
 from typing import TYPE_CHECKING, Union, Optional
-from ..models import Case, Platform, CaseType, Context, KFCoords
+from ..models import Case, Platform, CaseType, Context, KFCoords, KFType
 from ... import config
 
 if TYPE_CHECKING:
@@ -81,7 +81,7 @@ async def create_case(args: AnnouncerArgs, codemap: Platform, client: HalpyBOT) 
                 "case_type": case_type,
                 "planet": args["Planet"],
                 "pcoords": KFCoords(xcoord, ycoord),
-                "kftype": args["KFType"],
+                "kftype": getattr(KFType, args["KFType"].upper()),
             }
         )
     else:  # Must be standard Seal

--- a/halpybot/packages/case/caseutils.py
+++ b/halpybot/packages/case/caseutils.py
@@ -64,7 +64,7 @@ async def create_case(args: AnnouncerArgs, codemap: Platform, client: HalpyBOT) 
             {
                 "case_type": case_type,
                 "canopy_broken": True,
-                "can_synth": args["CanSynth"],
+                "can_synth": True if args["CanSynth"] == "Yes" else False,
                 "o2_timer": args["Oxygen"],
                 "hull_percent": int(args["Hull"]),
             }

--- a/halpybot/packages/case/caseutils.py
+++ b/halpybot/packages/case/caseutils.py
@@ -9,7 +9,7 @@ See license.md
 """
 from __future__ import annotations
 import re
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Union, Optional
 from ..models import Case, Platform, CaseType, Context
 from ... import config
 
@@ -100,7 +100,7 @@ async def get_case(ctx: Context, case_arg: str) -> Case:
 
 async def update_single_elem_case_prep(
     ctx: Context, case: Case, action: str, new_details, enum: bool = False
-):
+) -> Optional[str]:
     """
     Send the updated case details to the board, and handle errors
     NOTE: Can only handle a single updated value at a time.
@@ -112,9 +112,7 @@ async def update_single_elem_case_prep(
     try:
         await ctx.bot.board.mod_case(case.board_id, action, ctx.sender, **new_details)
     except ValueError:
-        return await ctx.reply(
-            f"{action} is already set to {new_item.name if enum else new_item}."
-        )
+        return f"{action} is already set to {new_item.name if enum else new_item}."
     for channel in config.channels.rescue_channels:
         await ctx.bot.message(
             channel,

--- a/halpybot/packages/case/caseutils.py
+++ b/halpybot/packages/case/caseutils.py
@@ -64,7 +64,7 @@ async def create_case(args: AnnouncerArgs, codemap: Platform, client: HalpyBOT) 
             {
                 "case_type": case_type,
                 "canopy_broken": True,
-                "can_synth": True if args["CanSynth"] == "Yes" else False,
+                "can_synth": True if args["CanSynth"].casefold() == "yes" else False,
                 "o2_timer": args["Oxygen"],
                 "hull_percent": int(args["Hull"]),
             }

--- a/halpybot/packages/case/caseutils.py
+++ b/halpybot/packages/case/caseutils.py
@@ -110,7 +110,7 @@ async def update_single_elem_case_prep(
     case: Case,
     action: str,
     new_key: str,
-    new_item: Union[str, Enum, int],
+    new_item: Union[str, Enum, int, KFCoords],
     enum: bool = False,
 ) -> Optional[str]:
     """

--- a/halpybot/packages/models/__init__.py
+++ b/halpybot/packages/models/__init__.py
@@ -11,7 +11,7 @@ See license.md
 from .edsm_classes import Coordinates, Location, SystemInfo
 from .user import User, UserError, NoUserFound
 from .context import Context, HelpArguments
-from .case import Case, Platform, KFCoords, Status
+from .case import Case, Platform, KFCoords, Status, CaseType
 from .seal import Seal
 
 __all__ = [
@@ -27,5 +27,6 @@ __all__ = [
     "Platform",
     "KFCoords",
     "Status",
+    "CaseType",
     "Seal",
 ]

--- a/halpybot/packages/models/__init__.py
+++ b/halpybot/packages/models/__init__.py
@@ -11,7 +11,7 @@ See license.md
 from .edsm_classes import Coordinates, Location, SystemInfo
 from .user import User, UserError, NoUserFound
 from .context import Context, HelpArguments
-from .case import Case, Platform, KFCoords, Status, CaseType
+from .case import Case, Platform, KFCoords, Status, CaseType, KFType
 from .seal import Seal
 
 __all__ = [
@@ -28,5 +28,6 @@ __all__ = [
     "KFCoords",
     "Status",
     "CaseType",
+    "KFType",
     "Seal",
 ]

--- a/halpybot/packages/models/case.py
+++ b/halpybot/packages/models/case.py
@@ -33,6 +33,15 @@ class Status(Enum):
     INACTIVE = 3
 
 
+class CaseType(Enum):
+    """What Type of Seal Case"""
+
+    SEAL = 1
+    BLACK = 2
+    BLUE = 3
+    FISH = 4
+
+
 @define(frozen=True)
 class KFCoords:
     """KingFisher Coordinate Object"""
@@ -51,6 +60,7 @@ class Case:
     system: str
     platform: Platform
     board_id: int
+    case_type: CaseType
     creation_time: DateTime = field(factory=lambda: now(tz="utc"))
     updated_time: DateTime = field(factory=lambda: now(tz="utc"))
     status: Status = Status.ACTIVE

--- a/halpybot/packages/models/case.py
+++ b/halpybot/packages/models/case.py
@@ -73,7 +73,7 @@ class Case:
 
     # Da Optionalz
     irc_nick: Optional[str] = None
-    can_synth: Optional[str] = None
+    can_synth: Optional[bool] = None
     o2_timer: Optional[str] = None
 
     # For Seal Cases

--- a/halpybot/packages/models/case.py
+++ b/halpybot/packages/models/case.py
@@ -50,6 +50,15 @@ class KFCoords:
     y: float
 
 
+class KFType(Enum):
+    """Kingfisher Case Subtypes"""
+
+    LIFT = 0
+    GOLF = 1
+    PUCK = 2
+    PICK = 3
+
+
 @define(frozen=True, str=False)
 class Case:
     """The Case Object - Tracking All The Things!"""
@@ -83,7 +92,7 @@ class Case:
     # For Kingfisher Cases
     planet: Optional[str] = None
     pcoords: Optional[KFCoords] = None
-    kftype: Optional[str] = None
+    kftype: Optional[KFType] = None
 
     def __str__(self) -> str:
         """Format case information in a ready-to-be-sent format
@@ -117,7 +126,7 @@ class Case:
                 f"KF Details:\n"
                 f"   Planet: {self.planet}\n"
                 f"   Coordinates: {self.pcoords}\n"
-                f"   Case Type: {self.kftype}\n"
+                f"   Case Type: {self.kftype.name}\n"
             )
         elif self.case_type in (CaseType.BLACK, CaseType.BLUE):
             message += (

--- a/halpybot/packages/models/case.py
+++ b/halpybot/packages/models/case.py
@@ -30,6 +30,7 @@ class Status(Enum):
     ACTIVE = 0
     CLOSED = 1
     DELAYED = 2
+    INACTIVE = 3
 
 
 @define(frozen=True)

--- a/halpybot/packages/models/case.py
+++ b/halpybot/packages/models/case.py
@@ -89,13 +89,13 @@ class Case:
         message = (
             f"Here's the self listing for Case ID {self.board_id}:\n "
             f"General Details: \n"
-            f"    Client: {self.client_name}\n"
-            f"    System: {self.system}\n"
-            f"    Platform: {plt}\n"
-            f"    Case Created: {created} ago\n"
-            f"    Case Updated: {updated} ago\n"
-            f"    Case Status: {self.status.name}\n"
-            f"    Client Welcomed: {'Yes' if self.welcomed else 'No'}\n"
+            f"   Client: {self.client_name}\n"
+            f"   System: {self.system}\n"
+            f"   Platform: {plt}\n"
+            f"   Case Created: {created} ago\n"
+            f"   Case Updated: {updated} ago\n"
+            f"   Case Status: {self.status.name}\n"
+            f"   Client Welcomed: {'Yes' if self.welcomed else 'No'}\n"
         )
         if self.irc_nick:
             message += f"   IRC Nickname: {self.irc_nick}\n"
@@ -121,7 +121,7 @@ class Case:
         if self.case_notes:
             case_notes = "\n      ".join(self.case_notes)
         else:
-            case_notes = "      None Yet!"
+            case_notes = "None Yet!"
         message += (
             f"Responder Details:\n"
             f"   Dispatchers: {', '.join(self.dispatchers) if self.dispatchers else 'None Yet!'}\n"

--- a/halpybot/packages/models/case.py
+++ b/halpybot/packages/models/case.py
@@ -118,10 +118,14 @@ class Case:
             )
         else:
             message += f"Case Details:\n" f"   Hull Remaining: {self.hull_percent}\n"
+        if self.case_notes:
+            case_notes = "\n      ".join(self.case_notes)
+        else:
+            case_notes = "      None Yet!"
         message += (
             f"Responder Details:\n"
             f"   Dispatchers: {', '.join(self.dispatchers) if self.dispatchers else 'None Yet!'}\n"
             f"   Responders: {', '.join(self.responders) if self.responders else 'None Yet!'}\n"
-            f"   Notes: {self.case_notes if self.case_notes else 'None Yet!'}"
+            f"   Notes: \n      {case_notes}"
         )
         return message

--- a/halpybot/packages/models/case.py
+++ b/halpybot/packages/models/case.py
@@ -112,14 +112,14 @@ class Case:
             message += f"   IRC Nickname: {self.irc_nick}\n"
         if self.closed_to:
             message += f"   Case Closed To: {self.closed_to}\n"  # TODO: Translate to Seal Name (#333)
-        elif self.planet:
+        if self.case_type == CaseType.FISH:
             message += (
                 f"KF Details:\n"
                 f"   Planet: {self.planet}\n"
                 f"   Coordinates: {self.pcoords}\n"
                 f"   Case Type: {self.kftype}\n"
             )
-        elif self.can_synth:
+        elif self.case_type in (CaseType.BLACK, CaseType.BLUE):
             message += (
                 f"Code Black Details:\n"
                 f"   Hull Remaining: {self.hull_percent}\n"

--- a/halpybot/server/server_announcer.py
+++ b/halpybot/server/server_announcer.py
@@ -11,7 +11,7 @@ See license.md
 
 from typing import Dict
 from aiohttp import web, web_request
-from ..packages.announcer import AnnouncementError, AlreadyExistsError
+from ..packages.announcer import AnnouncementError, AlreadyExistsError, KFCoordsError
 from ..packages.ircclient import HalpyBOT
 from .server import APIConnector
 from .auth import authenticate
@@ -47,6 +47,8 @@ async def announce(request: web_request.Request):
         raise web.HTTPOk
     except AlreadyExistsError:
         raise web.HTTPConflict from AnnouncementError
+    except KFCoordsError:
+        raise web.HTTPBadRequest from AnnouncementError
     except AnnouncementError:
         raise web.HTTPInternalServerError from AnnouncementError
 


### PR DESCRIPTION
Relies upon #334

Key Features:
- Establishes the base Case Management commands for changing static aspects of Cases. 
- Adds commands needed for Case Note Management to automatically fill some details of cases for notes.
- Automatically appends new note entries on key commands.
- Establishes the KFType and CaseType Enums
- Announcer now raises 400 Bad Request on invalid KingFisher coordinates

Also includes:
- A new configuration option to specify rescue channels, which should be subsets of joined channels.
- Improvements to the Board List command to allow platform or case type filtering.
- Removes a significant amount of now-redundant Debug code.
- Defines a number of new potential exception types for different situations.
- If a Client announcement is to include an IRC name, include that name in the announcement.
- Adds the Case Type to the initial case creation.
- Updates the Planet Coords and KF Type to use the proper Enums
- Refactors the get_case function to Packages from Commands
- Adds a new Enum value for Inactive cases.

Future Enhancements to be Investigated:
- Confirmation Loops on Some Commands

Closes #327, #111 