### PR TITLE
[Halpy-361] Update multiple dispatch commands to be able to use caseIDs and co

### DIFF
--- a/data/help/commands.json
+++ b/data/help/commands.json
@@ -4,7 +4,7 @@
       "aliases": [
         "syslookup"
       ],
-      "arguments": "[System Name]",
+      "arguments": "[System/CMDR/caseID]",
       "use": "Check if a system exists in EDSM"
     },
     "locate": {
@@ -24,17 +24,17 @@
     },
     "landmark": {
       "aliases": [],
-      "arguments": "[EDSM Valid Location]",
+      "arguments": "[System/CMDR/caseID]",
       "use": "Check if a given point is nearby a given Landmark System"
     },
     "dssa": {
       "aliases": [],
-      "arguments": "[EDSM Valid Location]",
+      "arguments": "[System/CMDR/caseID]",
       "use": "Check for the closest DSSA carrier to a given location."
     },
     "diversion": {
       "aliases": [],
-      "arguments": "[EDSM Valid Location]",
+      "arguments": "[System/CMDR/caseID]",
       "use": "Calculate the 5 closest FDEV-placed structures with repair capability to given location."
     },
     "coords": {

--- a/halpybot/commands/spansh.py
+++ b/halpybot/commands/spansh.py
@@ -11,7 +11,7 @@ See license.md
 from typing import List
 from loguru import logger
 from halpybot import config
-from .edsm import differentiate
+from .edsm import diff_handler
 from ..packages.exceptions import DifferentiateArgsIssue
 from ..packages.utils import spansh, dist_exceptions
 from ..packages.command import Commands, get_help_text
@@ -31,7 +31,7 @@ async def cmd_spansh(ctx: Context, args: List[str], cache_override):
         return await ctx.reply("Unable to comply. SPANSH module not enabled.")
     try:
         # Process provided arguments
-        points: Points = await differentiate(ctx=ctx, args=args)
+        points: Points = await diff_handler(ctx=ctx, args=args)
     except DifferentiateArgsIssue:
         # Arguments were malformed, user has already been informed, abort
         return await ctx.reply("Error encountered in Dist command, not continuing")

--- a/halpybot/halpyconfig.py
+++ b/halpybot/halpyconfig.py
@@ -225,7 +225,7 @@ class Spansh(BaseModel):
 
     enabled: bool = False
     efficiency: int = 60
-    calculations_timeout: int = 20
+    calculations_timeout: int = 60
     uri: AnyHttpUrl = "https://spansh.co.uk"
 
     @property

--- a/halpybot/packages/models/edsm_classes.py
+++ b/halpybot/packages/models/edsm_classes.py
@@ -76,8 +76,8 @@ class Point:
 
 @define()
 class Points:
-    """A pair of valid EDSM Points"""
+    """One or two valid EDSM Points and an optional jump range"""
 
     point_a: Point
-    point_b: Point
+    point_b: Optional[Point] = None
     jump_range: Optional[float] = None


### PR DESCRIPTION
This PR updates the ``!diversion``, ``!dssa``, ``!lookup`` and ``landmark`` commands to use the ``differentiate()`` function for their respective inputs so that users can use those commands with, most notably, case IDs. This change is a significant QoL improvement as it makes gettign this kind of information during cases a lot more convenient.
This PR also updates the ``differentiate()`` function to be able to work with just a single provided data point (it was originally designed with it always receiving two in mind).

Other Changes:
- Increases the spansh timeout when waiting for jobs to finish as they can often take more than 20 seconds.

Closes #361 