### PR TITLE
[Halpy-362] Add Admin command to combine multiple cases

### DIFF
--- a/data/help/commands.json
+++ b/data/help/commands.json
@@ -197,6 +197,11 @@
       "arguments": "[Board ID] [New Dispatchers]",
       "use": "Add a new dispatcher to a given case on the board."
     },
+    "combcases": {
+      "aliases:": [],
+      "arguments": "[Board ID to keep] [Board ID to combine]",
+      "use": "Combine two cases into a single case."
+    },
     "delcase": {
       "aliases:": [
         "remcase"

--- a/halpybot/commands/caseutils.py
+++ b/halpybot/commands/caseutils.py
@@ -753,6 +753,36 @@ async def cmd_editnote(ctx: Context, args: List[str], case: Case):
 
 
 # ADMINSTRATIVE MANAGEMENT
+@Commands.command("combcases")
+@needs_permission(Admin)
+@in_channel
+@gather_case(2)
+async def cmd_combine_cases(ctx: Context, args: List[str], case: Case):
+    """
+    Combines two cases into one, transferring all notes and responders from the second case to the first.
+
+    Usage: !combcases [board ID to keep] [board ID to combine]
+    Aliases: n/a
+    """
+    try:
+        case2: Case = await get_case(ctx, args[1])
+    except KeyError:
+        return await ctx.reply(f"No case found for {args[1]!r}.")
+    # case.case_notes.extend(case2.case_notes)
+    case.responders.extend(case2.responders)
+    case.dispatchers.extend(case2.dispatchers)
+    if case2.welcomed:
+        res_kwarg = {"welcomed": True}
+        await ctx.bot.board.mod_case(case_id=case.board_id, **res_kwarg)
+    case_comb_note = f"{ctx.sender} combined case {case2.board_id} into case {case.board_id} at {now(tz='UTC').to_time_string()}"
+    case_summary = f"{case2}"
+    case.case_notes.append(case_comb_note)
+    case.case_notes.append(case_summary)
+
+    await ctx.bot.board.del_case(case=case2)
+    return await ctx.reply(f"Combined case {case2.board_id} into case {case.board_id}.")
+
+
 @Commands.command("delcase", "remcase")
 @needs_permission(Admin)
 @in_channel


### PR DESCRIPTION
This PR adds a new command, ``combcases``, that allows Admins to combine two cases into one. This can be useful for example for instances where a Client bounces and rejoins by creating a new case or for delayed cases.
The command updates the Dispatchers and Responsers as well as the Welcomed status of the case to keep with the data of the case to be removed. It also adds the ``listcase`` response of the case to be removed to the the case to keep.
This PR also adds a corresponding help text.

Closes #362 