### PR TITLE
[Enhancement] Add Silent Welcome Option

### DIFF
--- a/data/help/commands.json
+++ b/data/help/commands.json
@@ -78,7 +78,7 @@
       "use": "Print out the current cases on the Board."
     },
     "listcase": {
-      "aliases:": [],
+      "aliases:": ["caseinfo"],
       "arguments": "[Board ID]",
       "use": "List specific details of a current case."
     },
@@ -169,6 +169,11 @@
       "aliases:": [],
       "arguments": "[Client Name or Board ID]",
       "use": "Welcome a client and add an identified Seal as a Dispatch responder."
+    },
+    "silentwelcome": {
+      "aliases:": ["swelcome", "wmute", "mute"],
+      "arguments": "[Client Name or Board ID]",
+      "use": "Suppress the welcome warning and add an identified Seal as a Dispatch responder."
     },
     "addresp": {
       "aliases:": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ tqdm = "^4.66.2"
 attrs = "^23.2.0 "
 cattrs = "^23.2.3 "
 loguru = "^0.7.0"
-pydantic = {extras = ["dotenv"], version = "^1.10.2"}
+pydantic = {extras = ["dotenv"], version = "^1.10.5"}
 sqlalchemy = "^2.0.29"
 beautifulsoup4 = "^4.12.3"
 lxml = "^5.2.1"


### PR DESCRIPTION
This PR adds a new command, silentwelcome (and its many aliases), that allows dispatchers to perform the same function as the Welcome command but without the output message. 

This also adds a new alias for the listcases command. 

Finally, reverts a bad dependency update.